### PR TITLE
Improve Performance When Loading Libraries

### DIFF
--- a/Stingray.xcodeproj/xcshareddata/xcschemes/Stingray.xcscheme
+++ b/Stingray.xcodeproj/xcshareddata/xcschemes/Stingray.xcscheme
@@ -32,8 +32,8 @@
    </TestAction>
    <LaunchAction
       buildConfiguration = "Release"
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
-      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"


### PR DESCRIPTION
Large libraries can benefit from higher batch sizes, and slowing our roll on how many libraries we attempt to download at a time.