### PR TITLE
Prevent unknown media types from causing crashes

### DIFF
--- a/Stingray/Models/MediaModel.swift
+++ b/Stingray/Models/MediaModel.swift
@@ -553,7 +553,7 @@ public enum MediaType: Decodable {
         case "Series":
             self = .tv(nil)
         default:
-            throw InitError.unknownType(MediaType.collections.rawValue)
+            throw InitError.unknownType(stringValue)
         }
     }
     


### PR DESCRIPTION
Prevent unknown media types from causing crashes by opting to fail the library instead of a fatal crash. In future versions of Stingray, this should be replaced with failing the media instead of the library.