### PR TITLE
perf: Use LazyHStack for horizontal scroll views

### DIFF
--- a/Stingray/HomeView.swift
+++ b/Stingray/HomeView.swift
@@ -118,7 +118,7 @@ fileprivate struct MediaPicker: View {
     
     var body: some View {
         ScrollView(.horizontal) {
-            HStack {
+            LazyHStack(spacing: 20) {
                 ForEach(pickerMedia) { media in
                     MediaNavigation(media: media, streamingService: streamingService, navigation: $navigation)
                 }
@@ -169,7 +169,7 @@ fileprivate struct MediaNavigationLoadingPicker: View {
     private let numOfPlaceholders: Int = Int.random(in: 4..<8)
     var body: some View {
         ScrollView(.horizontal) {
-            HStack {
+            LazyHStack(spacing: 20) {
                 ForEach(0..<numOfPlaceholders, id: \.self) { index in
                     MediaNavigationLoadingCard()
                         .opacity(Double(1 - (Double(index) / Double(numOfPlaceholders))))


### PR DESCRIPTION
## Summary
- Replace `HStack` with `LazyHStack` in `MediaPicker` and `MediaNavigationLoadingPicker` components
- Improves performance by only rendering visible items in horizontal scroll views
- Reduces memory usage, especially beneficial for large media libraries

## Changes
- `HomeView.swift`: Updated both horizontal scrollers to use `LazyHStack(spacing: 20)`

## Test Plan
- [ ] Verify horizontal scrolling works smoothly on Home view
- [ ] Check that media cards load correctly as they come into view
- [ ] Confirm no visual regressions in the dashboard rows