### PR TITLE
perf: Reduce playback status update frequency from 1s to 5s

### DIFF
--- a/Stingray/Models/StreamingServiceModel.swift
+++ b/Stingray/Models/StreamingServiceModel.swift
@@ -404,7 +404,9 @@ final class JellyfinPlayerProgress: PlayerProtocol {
     }
     
     func start() {
-        self.timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
+        // 5-second interval is sufficient for Jellyfin's playback tracking
+        // while reducing network requests by 80% compared to 1-second updates
+        self.timer = Timer.scheduledTimer(withTimeInterval: 5.0, repeats: true) { [weak self] _ in
             guard let self = self else { return }
             Task {
                 do {


### PR DESCRIPTION
## Summary
- Increase playback progress update interval from 1 second to 5 seconds
- Reduces network requests by 80% during video playback
- Jellyfin's progress tracking works accurately with 5-second intervals

## Changes
- `StreamingServiceModel.swift`: Changed timer interval from `1.0` to `5.0` seconds

## Rationale
Jellyfin's playback tracking doesn't require second-by-second precision. The server uses these updates for:
- Resume position tracking (5s granularity is acceptable)
- "Now Playing" dashboard display
- Playback session management

A 5-second interval provides sufficient accuracy while significantly reducing network overhead, especially beneficial on slower connections or when multiple clients are streaming.

## Test Plan
- [ ] Verify playback progress is saved correctly when stopping a video
- [ ] Confirm resume position works as expected
- [ ] Check that "Now Playing" status updates on Jellyfin dashboard