### PR TITLE
perf: Add shared UserModel instance to avoid repeated instantiation

### DIFF
--- a/Stingray/AddServerView.swift
+++ b/Stingray/AddServerView.swift
@@ -68,7 +68,7 @@ struct AddServerView: View {
         }
         .onAppear {
             print("Attempting to set up from storage")
-            guard let defaultUser = UserModel().getDefaultUser() else {
+            guard let defaultUser = UserModel.shared.getDefaultUser() else {
                 print("Failed to setup from storage, showing login screen")
                 return
             }

--- a/Stingray/LoginView.swift
+++ b/Stingray/LoginView.swift
@@ -8,8 +8,6 @@
 import SwiftUI
 
 struct LoginView: View {
-    internal var userModel = UserModel()
-    
     @Binding internal var loggedIn: LoginState
     @State internal var username: String = ""
     @State internal var password: String = ""

--- a/Stingray/Models/StreamingServiceModel.swift
+++ b/Stingray/Models/StreamingServiceModel.swift
@@ -111,8 +111,7 @@ public final class JellyfinModel: StreamingServiceProtocol {
     static func login(url: URL, username: String, password: String) async throws -> JellyfinModel {
         let networkAPI = JellyfinAdvancedNetwork(network: JellyfinBasicNetwork(address: url))
         let response = try await networkAPI.login(username: username, password: password)
-        let userModel = UserModel()
-        userModel.addUser(
+        UserModel.shared.addUser(
             User(
                 serviceURL: url,
                 serviceType: .Jellyfin(
@@ -123,7 +122,7 @@ public final class JellyfinModel: StreamingServiceProtocol {
                 displayName: response.userName
             )
         )
-        userModel.setDefaultUser(userID: response.userId)
+        UserModel.shared.setDefaultUser(userID: response.userId)
         return JellyfinModel(response: response, serviceURL: url)
     }
     

--- a/Stingray/Models/UserModel.swift
+++ b/Stingray/Models/UserModel.swift
@@ -9,6 +9,9 @@ import Foundation
 
 /// Basic data to store about the user
 final class UserModel {
+    /// Shared instance to avoid repeated instantiation
+    static let shared = UserModel()
+    
     /// Storage device to permanently store user data
     var storage: UserStorageProtocol
     

--- a/Stingray/PlayerViewModel.swift
+++ b/Stingray/PlayerViewModel.swift
@@ -79,11 +79,10 @@ final class PlayerViewModel: Hashable {
         self.mediaSource = mediaSource
         self.media = media
         
-        let userModel = UserModel()
         var subtitleID: String?
         var bitrate: Bitrate = .full
         
-        if let defaultUser = userModel.getDefaultUser() {
+        if let defaultUser = UserModel.shared.getDefaultUser() {
             // Setup subtitles
             if defaultUser.usesSubtitles {
                 subtitleID = self.mediaSource.subtitleStreams.first {
@@ -163,8 +162,7 @@ final class PlayerViewModel: Hashable {
         self.player?.play()
         
         // Update user settings
-        let userModel = UserModel()
-        guard var currentUser = userModel.getDefaultUser() else { return }
+        guard var currentUser = UserModel.shared.getDefaultUser() else { return }
         currentUser.usesSubtitles = self.playerProgress?.subtitleID != nil
         switch bitrate {
         case .full, .none:
@@ -172,7 +170,7 @@ final class PlayerViewModel: Hashable {
         case .limited(let newBitrate):
             currentUser.bitrate = newBitrate
         }
-        userModel.updateUser(currentUser)
+        UserModel.shared.updateUser(currentUser)
     }
     
     /// Creates a new player based on current state and new episode

--- a/Stingray/UserView.swift
+++ b/Stingray/UserView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 public struct UserView: View {
-    var users = UserModel()
+    var users = UserModel.shared
     var streamingService: any StreamingServiceProtocol
     @Binding var loggedIn: LoginState
     
@@ -69,10 +69,9 @@ public struct UserView: View {
                 .buttonStyle(.plain)
                 .contextMenu {
                     Button("Logout", systemImage: "tv.slash.fill", role: .destructive) {
-                        let userModel = UserModel()
-                        userModel.deleteUser(user.id)
+                        UserModel.shared.deleteUser(user.id)
                         if self.streamingService.userID == user.id {
-                            if let nextUser = userModel.getUsers().first {
+                            if let nextUser = UserModel.shared.getUsers().first {
                                 self.switchUser(user: nextUser)
                             } else {
                                 self.loggedIn = .loggedOut


### PR DESCRIPTION
## Summary
- Add a static `shared` property to `UserModel` for singleton access
- Update all call sites to use `UserModel.shared` instead of creating new instances
- Eliminates repeated storage initialization overhead

## Changes
- `UserModel.swift`: Add `static let shared = UserModel()`
- `StreamingServiceModel.swift`: Use `UserModel.shared` for user operations
- `UserView.swift`: Use `UserModel.shared` for user list and logout
- `PlayerViewModel.swift`: Use `UserModel.shared` for settings persistence  
- `AddServerView.swift`: Use `UserModel.shared` for auto-login check
- `LoginView.swift`: Remove unused `userModel` property

## Rationale
The app was creating 7+ new `UserModel` instances throughout the codebase, each initializing its own storage layer. Using a shared instance:
- Reduces object allocation overhead
- Ensures consistent state across the app
- Simplifies future enhancements (caching, observation)

## Test Plan
- [ ] Verify user login/logout works correctly
- [ ] Confirm user switching functions properly
- [ ] Check that playback settings (subtitles, bitrate) persist
- [ ] Test auto-login on app launch