### PR TITLE
perf: Add image caching layer for media thumbnails

### DIFF
--- a/Stingray/CachedAsyncImage.swift
+++ b/Stingray/CachedAsyncImage.swift
@@ -1,0 +1,106 @@
+//
+//  CachedAsyncImage.swift
+//  Stingray
+//
+//  Created for performance optimization.
+//
+
+import SwiftUI
+
+/// A view that asynchronously loads and displays an image with caching support.
+/// Uses NSCache for in-memory caching to avoid redundant network requests.
+struct CachedAsyncImage<Content: View, Placeholder: View>: View {
+    let url: URL?
+    let content: (Image) -> Content
+    let placeholder: () -> Placeholder
+    
+    @State private var cachedImage: UIImage?
+    @State private var isLoading = false
+    
+    init(
+        url: URL?,
+        @ViewBuilder content: @escaping (Image) -> Content,
+        @ViewBuilder placeholder: @escaping () -> Placeholder
+    ) {
+        self.url = url
+        self.content = content
+        self.placeholder = placeholder
+    }
+    
+    var body: some View {
+        Group {
+            if let cachedImage {
+                content(Image(uiImage: cachedImage))
+            } else {
+                placeholder()
+                    .task {
+                        await loadImage()
+                    }
+            }
+        }
+    }
+    
+    private func loadImage() async {
+        guard !isLoading, let url else { return }
+        
+        // Check cache first
+        if let cached = ImageCache.shared.get(for: url) {
+            cachedImage = cached
+            return
+        }
+        
+        isLoading = true
+        defer { isLoading = false }
+        
+        do {
+            let (data, _) = try await URLSession.shared.data(from: url)
+            if let image = UIImage(data: data) {
+                ImageCache.shared.set(image, for: url)
+                await MainActor.run {
+                    cachedImage = image
+                }
+            }
+        } catch {
+            // Silently fail - placeholder will remain visible
+        }
+    }
+}
+
+/// Thread-safe image cache using NSCache
+final class ImageCache: @unchecked Sendable {
+    static let shared = ImageCache()
+    
+    private let cache = NSCache<NSURL, UIImage>()
+    private let lock = NSLock()
+    
+    private init() {
+        // Configure cache limits
+        cache.countLimit = 100 // Max 100 images
+        cache.totalCostLimit = 50 * 1024 * 1024 // 50 MB
+    }
+    
+    func get(for url: URL) -> UIImage? {
+        lock.lock()
+        defer { lock.unlock() }
+        return cache.object(forKey: url as NSURL)
+    }
+    
+    func set(_ image: UIImage, for url: URL) {
+        lock.lock()
+        defer { lock.unlock() }
+        let cost = image.jpegData(compressionQuality: 1)?.count ?? 0
+        cache.setObject(image, forKey: url as NSURL, cost: cost)
+    }
+    
+    func remove(for url: URL) {
+        lock.lock()
+        defer { lock.unlock() }
+        cache.removeObject(forKey: url as NSURL)
+    }
+    
+    func clearAll() {
+        lock.lock()
+        defer { lock.unlock() }
+        cache.removeAllObjects()
+    }
+}

--- a/Stingray/MediaCardView.swift
+++ b/Stingray/MediaCardView.swift
@@ -20,7 +20,7 @@ struct MediaCard: View {
     var body: some View {
         VStack(spacing: 0) {
             if media.imageTags.primary != nil {
-                AsyncImage(url: url) { image in
+                CachedAsyncImage(url: url) { image in
                     image
                         .resizable()
                         .scaledToFill()


### PR DESCRIPTION
## Summary
- Add `CachedAsyncImage` view with in-memory caching via NSCache
- Replace `AsyncImage` with `CachedAsyncImage` in media card thumbnails
- Reduces redundant network requests when scrolling through media lists

## Changes
- **New file**: `CachedAsyncImage.swift`
  - `CachedAsyncImage<Content, Placeholder>`: Drop-in replacement for AsyncImage with caching
  - `ImageCache`: Thread-safe singleton using NSCache
  - Configurable limits: 100 images max, 50MB total
- `MediaCardView.swift`: Updated to use CachedAsyncImage

## How It Works
1. When an image URL is requested, check the cache first
2. If cached, display immediately without network request
3. If not cached, show placeholder (BlurHash), fetch image, cache it
4. Cache automatically evicts old entries when limits are reached

## Benefits
- **Faster scrolling**: Previously loaded images appear instantly
- **Reduced bandwidth**: No re-downloading when scrolling back
- **Better UX**: Smoother transitions with fewer loading states
- **Memory efficient**: NSCache auto-purges under memory pressure

## Future Improvements
Could extend caching to other AsyncImage usages (DetailMediaView, UserView) in follow-up PRs.

## Test Plan
- [ ] Scroll through a library with many items
- [ ] Scroll back up - images should appear instantly
- [ ] Navigate away and return - cached images should still load quickly
- [ ] Verify memory usage stays reasonable with large libraries