### PR TITLE
feat: Add Apple TV profile integration for multi-user support

### DIFF
--- a/Stingray/APIs/APIStorage.swift
+++ b/Stingray/APIs/APIStorage.swift
@@ -11,6 +11,8 @@ public enum StorageKeys: String {
     case defaultUserID = "defaultUserID"
     case userIDs = "userIDs"
     case user = "user"
+    /// Maps Apple TV profile identifiers to Jellyfin user IDs
+    case atvProfileMapping = "atvProfileMapping"
 }
 
 /// A protocol for abstracting access to local storage via key-value pairs

--- a/Stingray/AddServerView.swift
+++ b/Stingray/AddServerView.swift
@@ -68,20 +68,24 @@ struct AddServerView: View {
         }
         .onAppear {
             print("Attempting to set up from storage")
-            guard let defaultUser = UserModel().getDefaultUser() else {
+            
+            // Use TVProfileManager to determine which user to log in
+            // Priority: 1) ATV profile mapped user, 2) Default user
+            guard let userToLogin = TVProfileManager.shared.getUserForAppLaunch() else {
                 print("Failed to setup from storage, showing login screen")
                 return
             }
-            switch defaultUser.serviceType {
+            
+            switch userToLogin.serviceType {
             case .Jellyfin(let userJellyfin):
                 loggedIn = .loggedIn(
                     JellyfinModel(
-                        userDisplayName: defaultUser.displayName,
-                        userID: defaultUser.id,
-                        serviceID: defaultUser.serviceID,
+                        userDisplayName: userToLogin.displayName,
+                        userID: userToLogin.id,
+                        serviceID: userToLogin.serviceID,
                         accessToken: userJellyfin.accessToken,
                         sessionID: userJellyfin.sessionID,
-                        serviceURL: defaultUser.serviceURL
+                        serviceURL: userToLogin.serviceURL
                     )
                 )
             }

--- a/Stingray/TVProfileManager.swift
+++ b/Stingray/TVProfileManager.swift
@@ -1,0 +1,181 @@
+//
+//  TVProfileManager.swift
+//  Stingray
+//
+//  Manages Apple TV profile integration with Jellyfin users.
+//  When tvOS profile switches, the app relaunches - this manager
+//  handles auto-selecting the correct Jellyfin user on launch.
+//
+
+import Foundation
+#if os(tvOS)
+import TVUIKit
+#endif
+
+/// Manages the mapping between Apple TV profiles and Jellyfin users
+@Observable
+final class TVProfileManager {
+    /// Shared instance for app-wide access
+    static let shared = TVProfileManager()
+    
+    /// The current Apple TV profile identifier (nil if profiles not enabled)
+    private(set) var currentATVProfileID: String?
+    
+    /// Whether Apple TV multi-user profiles are available
+    private(set) var isProfilesAvailable: Bool = false
+    
+    private let storage: BasicStorageProtocol
+    
+    private init(storage: BasicStorageProtocol = DefaultsBasicStorage()) {
+        self.storage = storage
+        updateCurrentProfile()
+    }
+    
+    // MARK: - Profile Detection
+    
+    private func updateCurrentProfile() {
+        #if os(tvOS)
+        let userManager = TVUserManager()
+        if let identifier = userManager.currentUserIdentifier {
+            currentATVProfileID = identifier.uuidString
+            isProfilesAvailable = true
+            print("TVProfileManager: Current ATV Profile ID: \(identifier.uuidString)")
+        } else {
+            currentATVProfileID = nil
+            isProfilesAvailable = false
+            print("TVProfileManager: No ATV Profile detected (single-user or profiles disabled)")
+        }
+        #else
+        currentATVProfileID = nil
+        isProfilesAvailable = false
+        #endif
+    }
+    
+    // MARK: - Profile Mapping
+    
+    /// Get the Jellyfin user ID mapped to an Apple TV profile
+    func getMappedJellyfinUser(forATVProfile atvProfileID: String) -> String? {
+        let mappings = getProfileMappings()
+        return mappings[atvProfileID]
+    }
+    
+    /// Get the Apple TV profile ID mapped to a Jellyfin user
+    func getMappedATVProfile(forJellyfinUser jellyfinUserID: String) -> String? {
+        let mappings = getProfileMappings()
+        return mappings.first(where: { $0.value == jellyfinUserID })?.key
+    }
+    
+    /// Link the current Apple TV profile to a Jellyfin user
+    /// - Parameter jellyfinUserID: The Jellyfin user ID to link
+    /// - Returns: True if linking was successful
+    @discardableResult
+    func linkCurrentProfileToUser(_ jellyfinUserID: String) -> Bool {
+        guard let profileID = currentATVProfileID else {
+            print("TVProfileManager: Cannot link - no ATV profile detected")
+            return false
+        }
+        
+        var mappings = getProfileMappings()
+        
+        // Remove any existing mapping for this Jellyfin user (one-to-one mapping)
+        mappings = mappings.filter { $0.value != jellyfinUserID }
+        
+        // Add the new mapping
+        mappings[profileID] = jellyfinUserID
+        saveProfileMappings(mappings)
+        
+        print("TVProfileManager: Linked ATV profile to Jellyfin user \(jellyfinUserID)")
+        return true
+    }
+    
+    /// Unlink the current Apple TV profile from any Jellyfin user
+    func unlinkCurrentProfile() {
+        guard let profileID = currentATVProfileID else { return }
+        
+        var mappings = getProfileMappings()
+        mappings.removeValue(forKey: profileID)
+        saveProfileMappings(mappings)
+        
+        print("TVProfileManager: Unlinked current ATV profile")
+    }
+    
+    /// Unlink a specific Jellyfin user from any Apple TV profile
+    func unlinkUser(_ jellyfinUserID: String) {
+        var mappings = getProfileMappings()
+        let hadMapping = mappings.contains(where: { $0.value == jellyfinUserID })
+        mappings = mappings.filter { $0.value != jellyfinUserID }
+        saveProfileMappings(mappings)
+        
+        if hadMapping {
+            print("TVProfileManager: Unlinked Jellyfin user \(jellyfinUserID)")
+        }
+    }
+    
+    /// Check if the current Apple TV profile is linked to any Jellyfin user
+    var isCurrentProfileLinked: Bool {
+        guard let profileID = currentATVProfileID else { return false }
+        return getMappedJellyfinUser(forATVProfile: profileID) != nil
+    }
+    
+    /// Check if a specific Jellyfin user is linked to the current Apple TV profile
+    func isUserLinkedToCurrentProfile(_ jellyfinUserID: String) -> Bool {
+        guard let profileID = currentATVProfileID else { return false }
+        return getMappedJellyfinUser(forATVProfile: profileID) == jellyfinUserID
+    }
+    
+    /// Check if a Jellyfin user is linked to any ATV profile
+    func isUserLinked(_ jellyfinUserID: String) -> Bool {
+        return getMappedATVProfile(forJellyfinUser: jellyfinUserID) != nil
+    }
+    
+    // MARK: - Storage Helpers
+    
+    private func getProfileMappings() -> [String: String] {
+        guard let jsonString = storage.getString(.atvProfileMapping, id: ""),
+              let data = jsonString.data(using: .utf8),
+              let mappings = try? JSONDecoder().decode([String: String].self, from: data) else {
+            return [:]
+        }
+        return mappings
+    }
+    
+    private func saveProfileMappings(_ mappings: [String: String]) {
+        if let data = try? JSONEncoder().encode(mappings),
+           let jsonString = String(data: data, encoding: .utf8) {
+            storage.setString(.atvProfileMapping, id: "", value: jsonString)
+        }
+    }
+    
+    // MARK: - Auto-Login Support
+    
+    /// Get the Jellyfin user that should be auto-logged in based on the current ATV profile.
+    /// Returns nil if no profile is active or no mapping exists.
+    func getAutoLoginUser() -> User? {
+        guard let profileID = currentATVProfileID,
+              let jellyfinUserID = getMappedJellyfinUser(forATVProfile: profileID) else {
+            return nil
+        }
+        
+        let userModel = UserModel()
+        return userModel.getUsers().first(where: { $0.id == jellyfinUserID })
+    }
+    
+    /// Determine which user should be used on app launch.
+    /// Priority: 1) ATV profile mapped user, 2) Default user
+    func getUserForAppLaunch() -> User? {
+        // First, try to get a user based on ATV profile mapping
+        if let profileUser = getAutoLoginUser() {
+            print("TVProfileManager: Using ATV profile-mapped user: \(profileUser.displayName)")
+            return profileUser
+        }
+        
+        // Fall back to the default user
+        let userModel = UserModel()
+        if let defaultUser = userModel.getDefaultUser() {
+            print("TVProfileManager: Using default user: \(defaultUser.displayName)")
+            return defaultUser
+        }
+        
+        return nil
+    }
+}


### PR DESCRIPTION
## Summary
Implement automatic Jellyfin user switching based on Apple TV profiles. When tvOS profiles are enabled and a mapping exists, the app automatically logs in the correct Jellyfin user on launch.

## How It Works

### On App Launch
1. `TVProfileManager` checks the current tvOS profile using `TVUserManager`
2. If a Jellyfin user is mapped to this profile, that user is automatically logged in
3. If no mapping exists, falls back to the default user behavior

### On Profile Switch
When a user switches their Apple TV profile:
1. tvOS terminates the app (standard behavior)
2. App relaunches with the new profile context
3. The mapped Jellyfin user is automatically selected

### Linking Users to Profiles
Users can link their Jellyfin account to the current ATV profile via the user selection screen:
- A chain icon indicates which user is linked to the current profile
- Context menu provides "Link to Apple TV Profile" / "Unlink" options

## Changes

**New Files:**
- `TVProfileManager.swift` - Singleton manager for ATV profile detection and user mapping

**Modified Files:**
- `APIStorage.swift` - Added `atvProfileMapping` storage key
- `AddServerView.swift` - Uses `TVProfileManager.getUserForAppLaunch()` for auto-login
- `UserView.swift` - Added profile linking UI (indicator + context menu)

## UI Changes

### User Selection Screen
- Link icon overlay on users linked to current ATV profile
- New context menu options:
  - "Link to Apple TV Profile" (when not linked)
  - "Unlink from Apple TV Profile" (when linked)
- Profile options only shown when ATV multi-user is enabled

## Technical Details

- Uses `TVUserManager.currentUserIdentifier` to detect current profile
- Mappings stored as JSON in UserDefaults (shared app group)
- One-to-one mapping: each Jellyfin user can only be linked to one ATV profile
- Graceful handling when profiles are disabled or not available

## Test Plan
- [ ] Enable Apple TV profiles in Settings > Users and Accounts
- [ ] Create multiple tvOS profiles
- [ ] Add multiple Jellyfin users to the app
- [ ] Link different Jellyfin users to different ATV profiles
- [ ] Switch ATV profiles and verify correct Jellyfin user is auto-selected
- [ ] Verify link indicator appears on linked users
- [ ] Test unlinking and re-linking users
- [ ] Verify deleted users are automatically unlinked
- [ ] Test fallback to default user when no mapping exists