### PR TITLE
fix: Resolve stale Continue Watching data and HDR playback issues

### DIFF
--- a/Stingray/APIs/APINetwork.swift
+++ b/Stingray/APIs/APINetwork.swift
@@ -449,10 +449,19 @@ final class JellyfinAdvancedNetwork: AdvancedNetworkProtocol {
             URLQueryItem(name: "audioStreamIndex", value: String(audioID)),
             URLQueryItem(name: "videoStreamIndex", value: String(videoID)),
             URLQueryItem(name: "videoBitRate", value: String(bitrate)),
-            // Let Jellyfin decide based on client capabilities
-            URLQueryItem(name: "audioCodec", value: "aac,ac3,eac3,alac,mp3"),
+            // Audio codecs supported by Apple TV
+            URLQueryItem(name: "audioCodec", value: "aac,ac3,eac3,truehd,dts,alac,mp3,flac"),
+            // Video codecs supported by Apple TV (h264 and hevc including 10-bit HDR)
             URLQueryItem(name: "videoCodec", value: "h264,hevc"),
-            URLQueryItem(name: "profile", value: "main")
+            // HEVC profiles: main (8-bit SDR), main10 (10-bit for HDR content)
+            // Fixes issue #14: HDR content was being transcoded to SDR due to "main" only profile
+            URLQueryItem(name: "videoProfile", value: "main,main10,main 10"),
+            // Video range types supported by Apple TV 4K:
+            // - SDR: Standard dynamic range
+            // - HDR10: HDR10 static metadata
+            // - HLG: Hybrid Log-Gamma
+            // - DOVIWithHDR10/DOVIWithHLG: Dolby Vision with fallback layer (profile 5, 7, 8)
+            URLQueryItem(name: "videoRangeType", value: "SDR,HDR10,HLG,DOVIWithHDR10,DOVIWithHLG")
         ]
         
         if let subtitleID = subtitleID {

--- a/Stingray/HomeView.swift
+++ b/Stingray/HomeView.swift
@@ -75,14 +75,14 @@ fileprivate struct DashboardRow: View {
             default:
                 Text(title)
                     .font(.title2.bold())
-                    .task {
-                        // Check if we already have cached data
-                        if let cachedMedia = cache[title] {
-                            status = cachedMedia.isEmpty ? .empty : .complete(cachedMedia)
-                            return
+                    .task(id: streamingService.userID) {
+                        // Show cached data immediately if available (prevents flicker)
+                        if let cachedMedia = cache[title], !cachedMedia.isEmpty {
+                            status = .complete(cachedMedia)
                         }
                         
-                        // Only fetch if not cached
+                        // Always fetch fresh data in background to ensure accuracy
+                        // This fixes issue #16 where "Continue Watching" shows stale episodes
                         let response = await fetchMedia()
                         cache[title] = response
                         status = response.isEmpty ? .empty : .complete(response)


### PR DESCRIPTION
## Summary

This PR fixes two user-reported bugs:

- **Fixes #14**: HDR content not playing in HDR - always transcoding
- **Fixes #16**: "Continue Watching" desynced

---

## Issue #16: Continue Watching Shows Stale Data

### Problem
When starting Stingray and quickly clicking a series, users see old episodes instead of their current progress. The "Continue Watching" row shows stale cached data.

### Root Cause
`DashboardRow` in `HomeView.swift` was returning early if cached data existed, skipping the fetch of fresh data:

```swift
// OLD CODE
if let cachedMedia = cache[title] {
    status = cachedMedia.isEmpty ? .empty : .complete(cachedMedia)
    return  // <-- Never fetches fresh data!
}
```

### Fix
Now shows cached data immediately (prevents UI flicker) while **always** fetching fresh data in the background:

```swift
// NEW CODE
// Show cached immediately if available
if let cachedMedia = cache[title], !cachedMedia.isEmpty {
    status = .complete(cachedMedia)
}

// Always fetch fresh data
let response = await fetchMedia()
cache[title] = response
status = response.isEmpty ? .empty : .complete(response)
```

Also added `task(id: streamingService.userID)` so data refreshes when switching users.

---

## Issue #14: HDR Content Playing as SDR (Gray Colors)

### Problem
HDR10 content plays with washed-out gray colors. Jellyfin transcodes HDR to SDR instead of passing through.

### Root Cause
The streaming parameters used `profile: main` which **only supports 8-bit SDR video**:

```swift
// OLD CODE
URLQueryItem(name: "videoCodec", value: "h264,hevc"),
URLQueryItem(name: "profile", value: "main")  // <-- 8-bit only!
```

### Fix
Updated parameters to properly declare Apple TV 4K HDR capabilities:

```swift
// NEW CODE
URLQueryItem(name: "videoCodec", value: "h264,hevc"),
URLQueryItem(name: "videoProfile", value: "main,main10,main 10"),  // 10-bit support
URLQueryItem(name: "videoRangeType", value: "SDR,HDR10,HLG,DOVIWithHDR10,DOVIWithHLG")
```

This tells Jellyfin the client supports:
| Format | Description |
|--------|-------------|
| SDR | Standard dynamic range |
| HDR10 | Static HDR metadata (10-bit HEVC) |
| HLG | Hybrid Log-Gamma |
| DOVIWithHDR10 | Dolby Vision profile 5/7/8 with HDR10 fallback |
| DOVIWithHLG | Dolby Vision with HLG fallback |

Also added TrueHD, DTS, and FLAC to supported audio codecs for HD audio passthrough.

---

## Test Plan

### Issue #16
- [ ] Open app with existing watch progress on a series
- [ ] Navigate to Home tab and observe "Next Up" row
- [ ] Verify it shows the correct episode (not old cached episode)
- [ ] Switch users and verify data refreshes

### Issue #14
- [ ] Play HDR10 content on Apple TV 4K
- [ ] Verify colors appear vibrant (not gray/washed out)
- [ ] Check Jellyfin dashboard to confirm no transcoding (direct play)
- [ ] Test Dolby Vision content if available