### PR TITLE
fix: Resolve HTTPS URL parsing for reverse proxies with subpaths

### DIFF
--- a/Stingray/AddServerView.swift
+++ b/Stingray/AddServerView.swift
@@ -95,7 +95,25 @@ struct AddServerView: View {
         case .http:
             url = URL(string: "http://\(httpHostname):\(httpPort)")
         case .https:
-            url = URL(string: "https://\(httpHostname)")
+            // Normalize the URL input:
+            // 1. Strip any existing protocol (user might enter "https://example.com")
+            // 2. Remove trailing slashes for consistency
+            var normalizedHost = httpHostname
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            
+            // Remove protocol prefix if user included it (fixes issue #7)
+            if normalizedHost.lowercased().hasPrefix("https://") {
+                normalizedHost = String(normalizedHost.dropFirst(8))
+            } else if normalizedHost.lowercased().hasPrefix("http://") {
+                normalizedHost = String(normalizedHost.dropFirst(7))
+            }
+            
+            // Remove trailing slash
+            while normalizedHost.hasSuffix("/") {
+                normalizedHost = String(normalizedHost.dropLast())
+            }
+            
+            url = URL(string: "https://\(normalizedHost)")
         }
         guard let url else {
             error = "Invalid URL"

--- a/Stingray/Models/URLExtension.swift
+++ b/Stingray/Models/URLExtension.swift
@@ -11,20 +11,40 @@ import Foundation
 extension URL {
     /// Quickly add URL parameters to a URL
     /// - Parameters:
-    ///   - path: Relative path to a resource
+    ///   - path: Relative path to a resource (e.g., "/Users/AuthenticateByName")
     ///   - urlParams: Parameters to add
     /// - Returns: The built URL
+    ///
+    /// This method properly handles base URLs with paths (e.g., https://example.com/jellyfin)
+    /// by appending the new path instead of replacing it. This fixes issue #7 where
+    /// Jellyfin servers behind a reverse proxy with a subpath couldn't connect.
     func buildURL(path: String, urlParams: [URLQueryItem]?) -> URL? {
-        guard let url = URL(string: path, relativeTo: self) else {
+        // Use URLComponents to properly construct the URL
+        guard var components = URLComponents(url: self, resolvingAgainstBaseURL: true) else {
             return nil
         }
         
+        // Get the existing base path (e.g., "/jellyfin" from "https://example.com/jellyfin")
+        let basePath = components.path
+        
+        // Construct the full path by combining base path with the API path
+        // Handle cases where basePath might be empty or just "/"
+        let normalizedBasePath = basePath == "/" ? "" : basePath
+        
+        // Remove leading slash from path if base path exists to avoid double slashes
+        let normalizedPath = path.hasPrefix("/") ? path : "/\(path)"
+        
+        // Combine paths
+        components.path = normalizedBasePath + normalizedPath
+        
         // Add query parameters if provided
         if let urlParams = urlParams, !urlParams.isEmpty {
-            var components = URLComponents(url: url, resolvingAgainstBaseURL: true)
-            components?.queryItems = urlParams
-            return components?.url
+            // Preserve any existing query items and add new ones
+            var existingItems = components.queryItems ?? []
+            existingItems.append(contentsOf: urlParams)
+            components.queryItems = existingItems
         }
-        return url
+        
+        return components.url
     }
 }


### PR DESCRIPTION
## Summary

Fixes #7: Stingray cannot find Jellyfin server

This fixes connection issues for users with Jellyfin behind a reverse proxy, especially those using:
- Subpaths like `https://example.com/jellyfin`
- Custom domains like `watch.example.com`

## Problems Fixed

### 1. Double Protocol Bug

If user enters the URL with `https://` prefix, the code was creating an invalid URL:

```
User enters: "https://mylocal.domain"
Result:      "https://https://mylocal.domain" ❌
```

### 2. Subpath Lost Bug

When Jellyfin is on a subpath (e.g., `/jellyfin`), API calls were losing the base path:

```
Base URL:     https://example.com/jellyfin
API call to:  /Users/AuthenticateByName
Expected:     https://example.com/jellyfin/Users/AuthenticateByName ✅
Actual:       https://example.com/Users/AuthenticateByName ❌
```

This explains why the user saw "no connection requests to traefik reverse proxy" - the requests were going to the wrong path!

## Changes

### AddServerView.swift
- Strip existing protocol prefix (`http://` or `https://`) from user input
- Trim whitespace and trailing slashes
- Prevents double-protocol URLs

### URLExtension.swift  
- Rewrote `buildURL()` to use `URLComponents` for proper URL manipulation
- Preserves base path when appending API paths
- Example: base `/jellyfin` + path `/Users/Auth` = `/jellyfin/Users/Auth`

## Test Matrix

| User Input | Protocol | Before Fix | After Fix |
|------------|----------|------------|-----------|
| `example.com` | HTTPS | `https://example.com` ✅ | `https://example.com` ✅ |
| `https://example.com` | HTTPS | `https://https://example.com` ❌ | `https://example.com` ✅ |
| `example.com/jellyfin` | HTTPS | API calls to wrong path ❌ | Correct path ✅ |
| `http://example.com` | HTTPS | Double protocol ❌ | `https://example.com` ✅ |
| `example.com/` | HTTPS | Trailing slash issues | Clean URL ✅ |

## Test Plan

- [ ] Enter `https://example.com` in URL field → should connect
- [ ] Enter `example.com` in URL field → should connect  
- [ ] Enter `example.com/jellyfin` (with subpath) → should connect
- [ ] Enter URL with trailing slash → should work
- [ ] Verify API calls include the subpath (check Jellyfin logs or reverse proxy)
