### PR TITLE
feat: Add animated splash screen with ripple effect

### DIFF
--- a/Stingray/APIs/APIStorage.swift
+++ b/Stingray/APIs/APIStorage.swift
@@ -11,6 +11,8 @@ public enum StorageKeys: String {
     case defaultUserID = "defaultUserID"
     case userIDs = "userIDs"
     case user = "user"
+    /// Whether to show the splash animation on app launch
+    case showSplashAnimation = "showSplashAnimation"
 }
 
 /// A protocol for abstracting access to local storage via key-value pairs

--- a/Stingray/AppSettingsView.swift
+++ b/Stingray/AppSettingsView.swift
@@ -1,0 +1,65 @@
+//
+//  AppSettingsView.swift
+//  Stingray
+//
+//  App-wide settings that users can configure.
+//
+
+import SwiftUI
+
+/// View for configuring app-wide settings
+struct AppSettingsView: View {
+    @State private var showSplashAnimation: Bool = AppSettings.shared.showSplashAnimation
+    
+    var body: some View {
+        List {
+            Section {
+                Toggle(isOn: $showSplashAnimation) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Splash Animation")
+                            .font(.body)
+                        Text("Show ripple animation when launching the app")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .onChange(of: showSplashAnimation) { _, newValue in
+                    AppSettings.shared.showSplashAnimation = newValue
+                }
+            } header: {
+                Text("Appearance")
+            }
+            
+            Section {
+                // Placeholder for future settings
+                HStack {
+                    Image(systemName: "info.circle")
+                        .foregroundStyle(.secondary)
+                    Text("More settings coming soon")
+                        .foregroundStyle(.secondary)
+                }
+            } header: {
+                Text("About")
+            } footer: {
+                VStack(alignment: .center, spacing: 8) {
+                    Text("Stingray")
+                        .font(.headline)
+                    if let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String {
+                        Text("Version \(version)")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.top, 20)
+            }
+        }
+        .navigationTitle("Settings")
+    }
+}
+
+#Preview {
+    NavigationStack {
+        AppSettingsView()
+    }
+}

--- a/Stingray/RippleSplashView.swift
+++ b/Stingray/RippleSplashView.swift
@@ -1,0 +1,160 @@
+//
+//  RippleSplashView.swift
+//  Stingray
+//
+//  Animated splash screen with expanding ripple effect.
+//
+
+import SwiftUI
+
+/// Animated splash view with expanding ripple circles and the Stingray logo
+struct RippleSplashView: View {
+    @State private var ripplePhase: CGFloat = 0
+    @State private var logoScale: CGFloat = 0.8
+    @State private var logoOpacity: Double = 0
+    
+    // Number of ripple rings
+    private let rippleCount = 4
+    
+    var body: some View {
+        GeometryReader { geometry in
+            ZStack {
+                // Background gradient matching app theme
+                LinearGradient(
+                    colors: [
+                        Color(red: 0, green: 0.145, blue: 0.223),
+                        Color(red: 0, green: 0.063, blue: 0.153)
+                    ],
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+                
+                // Ripple circles expanding from center
+                ForEach(0..<rippleCount, id: \.self) { index in
+                    RippleCircle(
+                        phase: ripplePhase,
+                        index: index,
+                        totalCount: rippleCount,
+                        maxRadius: max(geometry.size.width, geometry.size.height)
+                    )
+                }
+                
+                // Center logo/icon
+                VStack(spacing: 16) {
+                    // App icon - using a stingray-like shape
+                    Image(systemName: "play.tv.fill")
+                        .font(.system(size: 100, weight: .light))
+                        .foregroundStyle(
+                            LinearGradient(
+                                colors: [.white, .white.opacity(0.8)],
+                                startPoint: .top,
+                                endPoint: .bottom
+                            )
+                        )
+                        .shadow(color: .black.opacity(0.3), radius: 20, x: 0, y: 10)
+                    
+                    Text("Stingray")
+                        .font(.system(size: 36, weight: .semibold, design: .rounded))
+                        .foregroundStyle(.white)
+                        .shadow(color: .black.opacity(0.3), radius: 10, x: 0, y: 5)
+                }
+                .scaleEffect(logoScale)
+                .opacity(logoOpacity)
+            }
+        }
+        .ignoresSafeArea()
+        .onAppear {
+            startAnimations()
+        }
+    }
+    
+    private func startAnimations() {
+        // Animate logo entrance
+        withAnimation(.spring(response: 0.6, dampingFraction: 0.7)) {
+            logoScale = 1.0
+            logoOpacity = 1.0
+        }
+        
+        // Animate ripples continuously
+        withAnimation(.linear(duration: 2.0).repeatForever(autoreverses: false)) {
+            ripplePhase = 1.0
+        }
+    }
+}
+
+/// Individual ripple circle that expands and fades
+private struct RippleCircle: View {
+    let phase: CGFloat
+    let index: Int
+    let totalCount: Int
+    let maxRadius: CGFloat
+    
+    var body: some View {
+        Circle()
+            .stroke(
+                Color.white.opacity(opacity),
+                lineWidth: 2
+            )
+            .frame(width: radius, height: radius)
+            .opacity(circleOpacity)
+    }
+    
+    /// Staggered phase for each ring (0.0 to 1.0)
+    private var staggeredPhase: CGFloat {
+        let offset = CGFloat(index) / CGFloat(totalCount)
+        let adjusted = (phase + offset).truncatingRemainder(dividingBy: 1.0)
+        return adjusted
+    }
+    
+    /// Current radius based on animation phase
+    private var radius: CGFloat {
+        let minRadius: CGFloat = 50
+        return minRadius + (maxRadius - minRadius) * staggeredPhase
+    }
+    
+    /// Opacity decreases as circle expands
+    private var circleOpacity: Double {
+        return max(0, 1.0 - Double(staggeredPhase))
+    }
+    
+    /// Stroke opacity
+    private var opacity: Double {
+        return 0.4 * circleOpacity
+    }
+}
+
+// MARK: - App Settings Manager
+
+/// Simple manager for app-wide settings
+final class AppSettings {
+    static let shared = AppSettings()
+    
+    private let storage: BasicStorageProtocol
+    
+    private init() {
+        self.storage = DefaultsBasicStorage()
+    }
+    
+    /// Whether to show the splash animation on app launch
+    /// Defaults to true for new users
+    var showSplashAnimation: Bool {
+        get {
+            // Check if the key has ever been set
+            let key = StorageKeys.showSplashAnimation.rawValue
+            if UserDefaults.standard.object(forKey: key) == nil {
+                // First launch - default to true
+                return true
+            }
+            return storage.getBool(.showSplashAnimation, id: "")
+        }
+        set {
+            storage.setBool(.showSplashAnimation, id: "", value: newValue)
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    RippleSplashView()
+}

--- a/Stingray/StingrayApp.swift
+++ b/Stingray/StingrayApp.swift
@@ -18,15 +18,59 @@ struct StingrayApp: App {
     
     var body: some Scene {
         WindowGroup {
-            ContentView()
-                .background {
-                     LinearGradient(
-                        colors: [Color(red: 0, green: 0.145, blue: 0.223), Color(red: 0, green: 0.063, blue: 0.153)],
-                         startPoint: .top,
-                         endPoint: .bottom
-                     )
-                }
-                .ignoresSafeArea()
+            LaunchHostView {
+                ContentView()
+                    .background {
+                         LinearGradient(
+                            colors: [Color(red: 0, green: 0.145, blue: 0.223), Color(red: 0, green: 0.063, blue: 0.153)],
+                             startPoint: .top,
+                             endPoint: .bottom
+                         )
+                    }
+                    .ignoresSafeArea()
+            }
+        }
+    }
+}
+
+/// Wrapper view that shows the splash animation on app launch
+private struct LaunchHostView<Content: View>: View {
+    private let content: Content
+    
+    /// Whether splash animation is enabled in settings
+    private let splashEnabled: Bool
+    
+    @State private var showSplash: Bool
+
+    init(@ViewBuilder content: () -> Content) {
+        self.content = content()
+        // Read setting at init time
+        self.splashEnabled = AppSettings.shared.showSplashAnimation
+        // Initialize state based on setting
+        _showSplash = State(initialValue: AppSettings.shared.showSplashAnimation)
+    }
+
+    var body: some View {
+        ZStack {
+            content
+
+            if showSplash && splashEnabled {
+                RippleSplashView()
+                    .transition(.asymmetric(
+                        insertion: .identity,
+                        removal: .opacity.combined(with: .scale(scale: 1.1))
+                    ))
+                    .zIndex(10)
+            }
+        }
+        .task {
+            guard splashEnabled else { return }
+            
+            // Keep splash visible briefly on cold start
+            try? await Task.sleep(nanoseconds: 1_500_000_000) // 1.5 seconds
+            withAnimation(.easeOut(duration: 0.4)) {
+                showSplash = false
+            }
         }
     }
 }

--- a/Stingray/UserView.swift
+++ b/Stingray/UserView.swift
@@ -96,6 +96,31 @@ public struct UserView: View {
                 }
             }
             .buttonStyle(.plain)
+            
+            // Settings button
+            NavigationLink {
+                AppSettingsView()
+            } label: {
+                VStack(alignment: .center) {
+                    Image(systemName: "gearshape.fill")
+                        .resizable()
+                        .scaledToFit()
+                        .foregroundStyle(
+                            LinearGradient(
+                                colors: [.gray, .gray.opacity(0.7)],
+                                startPoint: .top,
+                                endPoint: .bottom
+                            )
+                        )
+                        .accessibilityLabel("Settings icon")
+                        .padding(.top, 30)
+                        .padding(.horizontal, 40)
+                    Spacer()
+                    Text("Settings")
+                        .font(.callout.bold())
+                }
+            }
+            .buttonStyle(.plain)
         }
     }
     


### PR DESCRIPTION
## Summary

Add a polished animated splash screen that displays when the app launches, featuring an expanding ripple effect and the Stingray logo. Users can disable this animation in settings if preferred.

## Visual Preview

### Animation Description
- **Background**: Deep blue gradient matching app theme
- **Ripple Effect**: 4 concentric white circles continuously expand outward from center while fading
- **Logo**: TV icon + "Stingray" text springs in with a bounce animation
- **Duration**: 1.5 seconds, then smooth fade-out with slight zoom
- **Exit**: Opacity fade combined with 1.1x scale for a "zoom through" effect

Think of it like dropping a pebble in calm water - rings ripple outward from the logo.

## New Files

| File | Description |
|------|-------------|
| `RippleSplashView.swift` | Animated splash with ripple circles and logo |
| `AppSettingsView.swift` | Settings screen with splash toggle |

## Modified Files

| File | Changes |
|------|---------|
| `StingrayApp.swift` | Added `LaunchHostView` wrapper for conditional splash display |
| `UserView.swift` | Added "Settings" button (gear icon) to user list |
| `APIStorage.swift` | Added `showSplashAnimation` storage key |

## Features

- **Ripple Animation**: 4 staggered rings expand from 50px to full screen
- **Spring Logo**: Bouncy entrance animation (0.8x → 1.0x scale)
- **User Configurable**: Toggle in Settings to disable
- **Persistent**: Setting saved across app launches
- **Default On**: Enabled by default for new users

## User Flow

1. App launches → Splash appears with ripple animation
2. After 1.5s → Splash fades out, main content visible
3. To disable: Users tab → Settings → Toggle "Splash Animation" off
4. Next launch respects the setting

## Technical Details

- Uses `@State` and `withAnimation` for smooth transitions
- `AppSettings` singleton with `BasicStorageProtocol` for persistence
- `GeometryReader` for responsive ripple sizing
- Continuous animation via `.repeatForever(autoreverses: false)`

## Test Plan

- [ ] App launch shows splash animation
- [ ] Splash fades out after ~1.5 seconds
- [ ] Settings toggle appears in Users tab
- [ ] Disabling toggle skips splash on next launch
- [ ] Re-enabling toggle restores splash animation
- [ ] Setting persists after app termination