### PR TITLE
Improved Error Display

### DIFF
--- a/Stingray/AddServerView.swift
+++ b/Stingray/AddServerView.swift
@@ -9,14 +9,14 @@ import SwiftUI
 
 struct AddServerView: View {
     @Binding var loggedIn: LoginState
-    @State var httpProcol: HttpProtocol = .http
-    @State var httpHostname: String = ""
-    @State var httpPort: String = "8096"
-    @State var username: String = ""
-    @State var password: String = ""
-    @State var error: RError? = nil
-    @State var errorSummary: String = ""
-    @State var awaitingLogin: Bool = false
+    @State private var httpProcol: HttpProtocol = .http
+    @State private var httpHostname: String = ""
+    @State private var httpPort: String = "8096"
+    @State private var username: String = ""
+    @State private var password: String = ""
+    @State private var error: RError?
+    @State private var errorSummary: String = ""
+    @State private var awaitingLogin: Bool = false
     
     var body: some View {
         VStack {

--- a/Stingray/DashboardView.swift
+++ b/Stingray/DashboardView.swift
@@ -19,7 +19,7 @@ struct DashboardView: View {
             VStack {
                 switch streamingService.libraryStatus {
                 case .waiting, .retrieving: ProgressView()
-                case .error(let err): ErrorView(error: err, summary: "The server formatted the library metadata unexpectedly.")
+                case .error(let err): ErrorView(error: err, summary: "The server formatted the library's metadata unexpectedly.")
                 case .available(let libraries), .complete(let libraries):
                     TabView(selection: $selectedTab) {
                         Tab(value: "users") {

--- a/Stingray/DashboardView.swift
+++ b/Stingray/DashboardView.swift
@@ -18,12 +18,8 @@ struct DashboardView: View {
         NavigationStack(path: $navigationPath) {
             VStack {
                 switch streamingService.libraryStatus {
-                case .waiting, .retrieving:
-                    ProgressView()
-                case .error(let err):
-                    Text("Error loading libraries: \(err.rDescription())")
-                        .foregroundStyle(.red)
-                    
+                case .waiting, .retrieving: ProgressView()
+                case .error(let err): ErrorView(error: err, summary: "The server formatted the library metadata unexpectedly.")
                 case .available(let libraries), .complete(let libraries):
                     TabView(selection: $selectedTab) {
                         Tab(value: "users") {

--- a/Stingray/ErrorView.swift
+++ b/Stingray/ErrorView.swift
@@ -15,12 +15,15 @@ public struct ErrorView: View {
     let summary: String
     /// Tracks whether or not the error has been expanded
     @State private var isExpanded: Bool = false
+    /// Tracks the current focus for changing colors
+    @FocusState private var isFocused: Bool
     
     public var body: some View {
         Button { self.isExpanded = true }
-        label: { ErrorSummaryView(summary: summary) }
+        label: { ErrorSummaryView(summary: summary, altColors: isFocused) }
             .buttonStyle(.plain)
-            .padding()
+            .padding(.horizontal, 70)
+            .focused($isFocused, equals: true)
             .sheet(isPresented: $isExpanded) { ErrorExpandedView(error: error) }
     }
 }
@@ -29,17 +32,19 @@ public struct ErrorView: View {
 fileprivate struct ErrorSummaryView: View {
     /// User-facing error to show before expanding
     let summary: String
+    /// Should switch into a high-contrast mode
+    let altColors: Bool
     
     var body: some View {
         Text(summary)
-            .foregroundStyle(.red)
+            .foregroundStyle(altColors ? .black : .red)
             .padding()
             .background {
                 RoundedRectangle(cornerRadius: 20)
-                    .strokeBorder(.red, lineWidth: 2)
+                    .strokeBorder(altColors ? .clear : .red, lineWidth: 2)
                     .background(
                         RoundedRectangle(cornerRadius: 20)
-                            .fill(.red.opacity(0.25))
+                            .fill(altColors ? .clear : .red.opacity(0.25))
                     )
             }
     }
@@ -61,11 +66,11 @@ fileprivate struct ErrorExpandedView: View {
 }
 
 #Preview {
-    ErrorSummaryView(summary: "Stingray went kaplooey.")
+    ErrorSummaryView(summary: "Stingray went kaplooey.", altColors: false)
 }
 
 #Preview {
-    ErrorSummaryView(summary: "Stingray went kaplooey.")
+    ErrorSummaryView(summary: "Stingray went kaplooey.", altColors: false)
         .sheet(isPresented: .constant(true)) {
             ErrorExpandedView(error: NetworkError.decodeJSONFailed(JSONError.missingKey("Nerd", "Preview"), url: nil))
         }

--- a/Stingray/ErrorView.swift
+++ b/Stingray/ErrorView.swift
@@ -1,0 +1,72 @@
+//
+//  Error-View.swift
+//  Stingray
+//
+//  Created by Ben Roberts on 1/26/26.
+//
+
+import SwiftUI
+
+/// Shows a simple error and can expand into a full verbose error log.
+public struct ErrorView: View {
+    /// Recursive error thrown by Stingray
+    let error: RError
+    /// User-facing error to show before expanding
+    let summary: String
+    /// Tracks whether or not the error has been expanded
+    @State private var isExpanded: Bool = false
+    
+    public var body: some View {
+        Button { self.isExpanded = true }
+        label: { ErrorSummaryView(summary: summary) }
+            .buttonStyle(.plain)
+            .padding()
+            .sheet(isPresented: $isExpanded) { ErrorExpandedView(error: error) }
+    }
+}
+
+/// Show a summary of a greater error.
+fileprivate struct ErrorSummaryView: View {
+    /// User-facing error to show before expanding
+    let summary: String
+    
+    var body: some View {
+        Text(summary)
+            .foregroundStyle(.red)
+            .padding()
+            .background {
+                RoundedRectangle(cornerRadius: 20)
+                    .strokeBorder(.red, lineWidth: 2)
+                    .background(
+                        RoundedRectangle(cornerRadius: 20)
+                            .fill(.red.opacity(0.25))
+                    )
+            }
+    }
+}
+
+/// Show a verbose version of an RError
+fileprivate struct ErrorExpandedView: View {
+    /// Verbose error thrown by Stingray
+    let error: RError
+    
+    var body: some View {
+        VStack(alignment: .leading) {
+            Text("Error:")
+            Text(error.rDescription())
+        }
+        .padding(.horizontal, 50)
+        .padding(.vertical, 20)
+    }
+}
+
+#Preview {
+    ErrorSummaryView(summary: "Stingray went kaplooey.")
+}
+
+#Preview {
+    ErrorSummaryView(summary: "Stingray went kaplooey.")
+        .sheet(isPresented: .constant(true)) {
+            ErrorExpandedView(error: NetworkError.decodeJSONFailed(JSONError.missingKey("Nerd", "Preview"), url: nil))
+        }
+}

--- a/Stingray/LibraryView.swift
+++ b/Stingray/LibraryView.swift
@@ -22,7 +22,7 @@ public struct LibraryView: View {
             case .unloaded, .waiting:
                 ProgressView()
             case .error(let err):
-                ErrorView(error: err, summary: "The server formatted the library media unexpectedly.")
+                ErrorView(error: err, summary: "The server formatted the library's media unexpectedly.")
             case .available(let allMedia), .complete(let allMedia):
                 if !allMedia.isEmpty {
                     MediaGridView(allMedia: allMedia, streamingService: streamingService, navigation: $navigation)

--- a/Stingray/LibraryView.swift
+++ b/Stingray/LibraryView.swift
@@ -22,9 +22,7 @@ public struct LibraryView: View {
             case .unloaded, .waiting:
                 ProgressView()
             case .error(let err):
-                Text("Error: \(err.rDescription())")
-                    .foregroundStyle(.red)
-                    .padding(.vertical)
+                ErrorView(error: err, summary: "The server formatted the library media unexpectedly.")
             case .available(let allMedia), .complete(let allMedia):
                 if !allMedia.isEmpty {
                     MediaGridView(allMedia: allMedia, streamingService: streamingService, navigation: $navigation)

--- a/Stingray/Models/RError.swift
+++ b/Stingray/Models/RError.swift
@@ -151,8 +151,8 @@ public enum MediaError: RError {
     
     public var errorDescription: String {
         switch self {
-        case .unknownMediaType:
-            return "Unknown media type"
+        case .unknownMediaType(let mediaType):
+            return "Unknown media type \"\(mediaType)\""
         }
     }
     

--- a/Stingray/Models/RError.swift
+++ b/Stingray/Models/RError.swift
@@ -98,6 +98,9 @@ public enum JSONError: RError {
     public var next: (any RError)? {
         switch self {
         case .unexpectedKey(let err): return err
+        case .failedJSONDecode(_, let err):
+            if let rError = err as? RError { return rError }
+            return nil
         default: return nil
         }
     }
@@ -233,14 +236,14 @@ public enum LibraryErrors: RError {
 /// Errors related to logging in
 public enum AccountErrors: RError {
     /// Failed to log into server.
-    case loginFailed(RError)
+    case loginFailed(RError?)
     /// Failed to get the server's version,
     case serverVersionFailed(RError)
     
     public var next: (RError)? {
         switch self {
-        case .loginFailed(let next), .serverVersionFailed(let next):
-            return next
+        case .loginFailed(let next): return next
+        case .serverVersionFailed(let next): return next
         }
     }
     


### PR DESCRIPTION
Display summary versions of errors, with the ability to expand the error to show the entire recursive error message:
![New Error Message](https://github.com/user-attachments/assets/72b5900c-e702-4388-99c1-35c0e186c703)

The new view can be clicked on to reveal the `RError.rDescription()`
![New Large Error Message](https://github.com/user-attachments/assets/25c6ea4c-2446-4feb-b021-530ff2e6ce0f)

