### PR TITLE
Dynamic play button/menu

### DIFF
--- a/Stingray/DetailMediaView.swift
+++ b/Stingray/DetailMediaView.swift
@@ -457,6 +457,7 @@ fileprivate struct PlayNavigationView: View {
                     }
                 }
             }
+            .accessibilityLabel("Play button menu")
         }
         // If there's any that are somewhat played, present options to restart
         else {
@@ -469,7 +470,9 @@ fileprivate struct PlayNavigationView: View {
                                     PlayerViewModel(
                                         media: media,
                                         mediaSource: mediaSource,
-                                        startTime: CMTimeMakeWithSeconds(Double(mediaSource.startTicks / 10_000_000), preferredTimescale: 1),
+                                        startTime: CMTimeMakeWithSeconds(
+                                            Double(mediaSource.startTicks / 10_000_000), preferredTimescale: 1
+                                        ),
                                         streamingService: self.streamingService,
                                         seasons: self.seasons
                                     )

--- a/Stingray/DetailMediaView.swift
+++ b/Stingray/DetailMediaView.swift
@@ -198,6 +198,11 @@ public struct DetailMediaView: View {
             .animation(.spring(.smooth), value: shouldRevealBottomShelf)
         }
         .ignoresSafeArea()
+        .task { // Yep. I hate it too. Apple TVs are having issues selecting the play button if it changes type.
+            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(500)) {
+                self.focus = .play
+            }
+        }
         .onChange(of: focus) { _, newValue in
             switch newValue {
             case .media, .season, .overview:
@@ -210,7 +215,6 @@ public struct DetailMediaView: View {
                 break
             }
         }
-        .onAppear { focus = .play }
         .navigationDestination(for: PlayerViewModel.self) { vm in
             PlayerView(vm: vm, navigation: $navigation)
         }
@@ -403,7 +407,11 @@ fileprivate struct PlayNavigationView: View {
                     )
                 )
             } label: { Label(self.title, systemImage: "play.fill") }
+                .onAppear { self.focus = .play }
+                .accessibilityLabel("Play button menu")
                 .focused($focus, equals: .play)
+                .id(mediaSource.id)
+                .defaultFocus($focus, .play, priority: .userInitiated)
         }
         // If there are multiple sources but all unwatched, show only "play" options that start from beginning
         else if (mediaSources.allSatisfy { $0.startTicks == 0 }) {
@@ -422,9 +430,14 @@ fileprivate struct PlayNavigationView: View {
                     } label: {
                         Label(mediaSource.name, systemImage: "play.fill")
                     }
+                    .id(mediaSource.id)
                 }
             }
+            .onAppear { self.focus = .play }
             .accessibilityLabel("Play button menu")
+            .focused($focus, equals: .play)
+            .id("Play-button")
+            .defaultFocus($focus, .play, priority: .userInitiated)
         }
         // If there's any that are somewhat played, present options to restart
         else {
@@ -448,6 +461,7 @@ fileprivate struct PlayNavigationView: View {
                                 Label(mediaSource.name, systemImage: "play.fill")
                                 Text("Continue from \(String(ticks: mediaSource.startTicks))")
                             }
+                            .id(mediaSource.id)
                         }
                     }
                 }
@@ -466,11 +480,15 @@ fileprivate struct PlayNavigationView: View {
                         } label: {
                             Label(mediaSource.name, systemImage: "memories")
                         }
+                        .id(mediaSource.id)
                     }
                 }
             }
+            .onAppear { self.focus = .play }
             .accessibilityLabel("Play button menu")
             .focused($focus, equals: .play)
+            .id("Play-button")
+            .defaultFocus($focus, .play, priority: .userInitiated)
         }
     }
 }

--- a/Stingray/DetailMediaView.swift
+++ b/Stingray/DetailMediaView.swift
@@ -439,7 +439,7 @@ fileprivate struct PlayNavigationView: View {
         }
         // If there are multiple sources but all unwatched, show only "play" options that start from beginning
         else if (mediaSources.allSatisfy { $0.startTicks == 0 }) {
-            Menu("\(Image(systemName: "play.fill")) \(title)") {
+            Menu("\(Image(systemName: "play")) \(title)") {
                 ForEach(mediaSources, id: \.id) { mediaSource in
                     Button {
                         self.navigation.append(
@@ -460,7 +460,7 @@ fileprivate struct PlayNavigationView: View {
         }
         // If there's any that are somewhat played, present options to restart
         else {
-            Menu("\(Image(systemName: "play.fill")) \(title)") {
+            Menu("\(Image(systemName: "play")) \(title)") {
                 Section("Resume") {
                     ForEach(mediaSources, id: \.id) { mediaSource in
                         if mediaSource.startTicks != 0 {

--- a/Stingray/DetailMediaView.swift
+++ b/Stingray/DetailMediaView.swift
@@ -418,36 +418,14 @@ fileprivate struct PlayNavigationView: View {
             // Single item that's partially watched - show streamlined menu
             else {
                 Menu("\(Image(systemName: "play")) \(title)") {
-                    Button {
-                        self.navigation.append(
-                            PlayerViewModel(
-                                media: media,
-                                mediaSource: mediaSources[0],
-                                startTime: CMTimeMakeWithSeconds(
-                                    Double(mediaSources[0].startTicks / 10_000_000), preferredTimescale: 1
-                                ),
-                                streamingService: self.streamingService,
-                                seasons: self.seasons
-                            )
-                        )
-                    } label: {
+                    Button { navigateToPlayer(for: mediaSources[0], startTicks: mediaSources[0].startTicks) }
+                    label: {
                         Label("Resume \(media.title)", systemImage: "play.fill")
                         Text("Continue from \(String(ticks: mediaSources[0].startTicks))")
                     }
                     .id(mediaSources[0].id)
-                    Button {
-                        self.navigation.append(
-                            PlayerViewModel(
-                                media: media,
-                                mediaSource: mediaSources[0],
-                                startTime: .zero,
-                                streamingService: self.streamingService,
-                                seasons: self.seasons
-                            )
-                        )
-                    } label: {
-                        Label("Restart \(media.title)", systemImage: "memories")
-                    }
+                    Button { navigateToPlayer(for: mediaSources[0], startTicks: .zero) }
+                    label: { Label("Restart \(media.title)", systemImage: "memories") }
                     .id(mediaSources[0].id)
                 }
                 .onAppear { self.focus = .play }
@@ -463,19 +441,8 @@ fileprivate struct PlayNavigationView: View {
             if (mediaSources.allSatisfy { $0.startTicks == 0 }) {
                 Menu("\(Image(systemName: "play")) \(title)") {
                     ForEach(mediaSources, id: \.id) { mediaSource in
-                        Button {
-                            self.navigation.append(
-                                PlayerViewModel(
-                                    media: media,
-                                    mediaSource: mediaSource,
-                                    startTime: CMTimeMakeWithSeconds(Double(mediaSource.startTicks / 10_000_000), preferredTimescale: 1),
-                                    streamingService: self.streamingService,
-                                    seasons: self.seasons
-                                )
-                            )
-                        } label: {
-                            Label(mediaSource.name, systemImage: "play.fill")
-                        }
+                        Button { navigateToPlayer(for: mediaSource, startTicks: mediaSource.startTicks) }
+                        label: { Label(mediaSource.name, systemImage: "play.fill") }
                         .id(mediaSource.id)
                     }
                 }
@@ -491,18 +458,7 @@ fileprivate struct PlayNavigationView: View {
                     Section("Resume") {
                         ForEach(mediaSources, id: \.id) { mediaSource in
                             if mediaSource.startTicks != 0 {
-                                Button {
-                                    self.navigation.append(
-                                        PlayerViewModel(
-                                            media: media,
-                                            mediaSource: mediaSource,
-                                            startTime: CMTimeMakeWithSeconds(
-                                                Double(mediaSource.startTicks / 10_000_000), preferredTimescale: 1
-                                            ),
-                                            streamingService: self.streamingService,
-                                            seasons: self.seasons
-                                        )
-                                    )
+                                Button { navigateToPlayer(for: mediaSource, startTicks: mediaSource.startTicks)
                                 } label: {
                                     Label(mediaSource.name, systemImage: "play.fill")
                                     Text("Continue from \(String(ticks: mediaSource.startTicks))")
@@ -513,19 +469,8 @@ fileprivate struct PlayNavigationView: View {
                     }
                     Section("Restart") {
                         ForEach(mediaSources, id: \.id) { mediaSource in
-                            Button {
-                                self.navigation.append(
-                                    PlayerViewModel(
-                                        media: media,
-                                        mediaSource: mediaSource,
-                                        startTime: .zero,
-                                        streamingService: self.streamingService,
-                                        seasons: self.seasons
-                                    )
-                                )
-                            } label: {
-                                Label(mediaSource.name, systemImage: "memories")
-                            }
+                            Button { navigateToPlayer(for: mediaSource, startTicks: .zero) }
+                            label: { Label(mediaSource.name, systemImage: "memories") }
                             .id(mediaSource.id)
                         }
                     }
@@ -537,6 +482,20 @@ fileprivate struct PlayNavigationView: View {
                 .defaultFocus($focus, .play, priority: .userInitiated)
             }
         }
+    }
+    
+    func navigateToPlayer(for mediaSource: any MediaSourceProtocol, startTicks: Int) {
+        self.navigation.append(
+            PlayerViewModel(
+                media: media,
+                mediaSource: mediaSource,
+                startTime: CMTimeMakeWithSeconds(
+                    Double(startTicks / 10_000_000), preferredTimescale: 1
+                ),
+                streamingService: self.streamingService,
+                seasons: self.seasons
+            )
+        )
     }
 }
 

--- a/Stingray/DetailMediaView.swift
+++ b/Stingray/DetailMediaView.swift
@@ -421,45 +421,61 @@ fileprivate struct PlayNavigationView: View {
     }
     
     var body: some View {
-        Menu("\(Image(systemName: "play.fill")) \(title)") {
-            Section("Resume") {
-                ForEach(mediaSources, id: \.id) { mediaSource in
-                    Button {
-                        self.navigation.append(
-                            PlayerViewModel(
-                                media: media,
-                                mediaSource: mediaSource,
-                                startTime: CMTimeMakeWithSeconds(Double(mediaSource.startTicks / 10_000_000), preferredTimescale: 1),
-                                streamingService: self.streamingService,
-                                seasons: self.seasons
+        if mediaSources.count == 1 && self.mediaSources[0].startTicks == 0 {
+            let mediaSource = self.mediaSources[0]
+            Button {
+                self.navigation.append(
+                    PlayerViewModel(
+                        media: media,
+                        mediaSource: mediaSource,
+                        startTime: CMTimeMakeWithSeconds(Double(mediaSource.startTicks / 10_000_000), preferredTimescale: 1),
+                        streamingService: self.streamingService,
+                        seasons: self.seasons
+                    )
+                )
+            } label: { Label(mediaSource.name, systemImage: "play.fill") }
+                .focused($focus, equals: .play)
+        } else {
+            Menu("\(Image(systemName: "play.fill")) \(title)") {
+                Section("Resume") {
+                    ForEach(mediaSources, id: \.id) { mediaSource in
+                        Button {
+                            self.navigation.append(
+                                PlayerViewModel(
+                                    media: media,
+                                    mediaSource: mediaSource,
+                                    startTime: CMTimeMakeWithSeconds(Double(mediaSource.startTicks / 10_000_000), preferredTimescale: 1),
+                                    streamingService: self.streamingService,
+                                    seasons: self.seasons
+                                )
                             )
-                        )
-                    } label: {
-                        Label(mediaSource.name, systemImage: "play.fill")
-                        Text("Start from \(String(ticks: mediaSource.startTicks))")
+                        } label: {
+                            Label(mediaSource.name, systemImage: "play.fill")
+                            Text("Start from \(String(ticks: mediaSource.startTicks))")
+                        }
+                    }
+                }
+                Section("Restart") {
+                    ForEach(mediaSources, id: \.id) { mediaSource in
+                        Button {
+                            self.navigation.append(
+                                PlayerViewModel(
+                                    media: media,
+                                    mediaSource: mediaSource,
+                                    startTime: .zero,
+                                    streamingService: self.streamingService,
+                                    seasons: self.seasons
+                                )
+                            )
+                        } label: {
+                            Label(mediaSource.name, systemImage: "memories")
+                        }
                     }
                 }
             }
-            Section("Restart") {
-                ForEach(mediaSources, id: \.id) { mediaSource in
-                    Button {
-                        self.navigation.append(
-                            PlayerViewModel(
-                                media: media,
-                                mediaSource: mediaSource,
-                                startTime: .zero,
-                                streamingService: self.streamingService,
-                                seasons: self.seasons
-                            )
-                        )
-                    } label: {
-                        Label(mediaSource.name, systemImage: "memories")
-                    }
-                }
-            }
+            .accessibilityLabel("Play button menu")
+            .focused($focus, equals: .play)
         }
-        .accessibilityLabel("Play button menu")
-        .focused($focus, equals: .play)
     }
 }
 

--- a/Stingray/DetailMediaView.swift
+++ b/Stingray/DetailMediaView.swift
@@ -478,7 +478,7 @@ fileprivate struct PlayNavigationView: View {
                                 )
                             } label: {
                                 Label(mediaSource.name, systemImage: "play.fill")
-                                Text("Start from \(String(ticks: mediaSource.startTicks))")
+                                Text("Continue from \(String(ticks: mediaSource.startTicks))")
                             }
                         }
                     }

--- a/Stingray/DetailMediaView.swift
+++ b/Stingray/DetailMediaView.swift
@@ -463,19 +463,21 @@ fileprivate struct PlayNavigationView: View {
             Menu("\(Image(systemName: "play.fill")) \(title)") {
                 Section("Resume") {
                     ForEach(mediaSources, id: \.id) { mediaSource in
-                        Button {
-                            self.navigation.append(
-                                PlayerViewModel(
-                                    media: media,
-                                    mediaSource: mediaSource,
-                                    startTime: CMTimeMakeWithSeconds(Double(mediaSource.startTicks / 10_000_000), preferredTimescale: 1),
-                                    streamingService: self.streamingService,
-                                    seasons: self.seasons
+                        if mediaSource.startTicks != 0 {
+                            Button {
+                                self.navigation.append(
+                                    PlayerViewModel(
+                                        media: media,
+                                        mediaSource: mediaSource,
+                                        startTime: CMTimeMakeWithSeconds(Double(mediaSource.startTicks / 10_000_000), preferredTimescale: 1),
+                                        streamingService: self.streamingService,
+                                        seasons: self.seasons
+                                    )
                                 )
-                            )
-                        } label: {
-                            Label(mediaSource.name, systemImage: "play.fill")
-                            Text("Start from \(String(ticks: mediaSource.startTicks))")
+                            } label: {
+                                Label(mediaSource.name, systemImage: "play.fill")
+                                Text("Start from \(String(ticks: mediaSource.startTicks))")
+                            }
                         }
                     }
                 }

--- a/Stingray/DetailMediaView.swift
+++ b/Stingray/DetailMediaView.swift
@@ -341,38 +341,6 @@ public struct MediaMetadataView: View {
     }
 }
 
-// MARK: Movie play buttons
-fileprivate struct MovieNavigationView: View {
-    let media: any MediaProtocol
-    let mediaSource: any MediaSourceProtocol
-    let streamingService: any StreamingServiceProtocol
-    
-    @FocusState.Binding var focus: ButtonType?
-    @Binding var navigation: NavigationPath
-    
-    var body: some View {
-        let startTicks = Double(mediaSource.startTicks > 15 * 60 * 10_000_000 ? mediaSource.startTicks : 0)
-        Button {
-            navigation.append(
-                PlayerViewModel(
-                    media: media,
-                    mediaSource: mediaSource,
-                    startTime: CMTimeMakeWithSeconds(Double(startTicks / 10_000_000), preferredTimescale: 1),
-                    streamingService: streamingService,
-                    seasons: nil
-                )
-            )
-        } label: {
-            if startTicks != 0 { // Restart if watched less than 15 minutes
-                Text("Play \(mediaSource.name) - \(String(ticks: mediaSource.startTicks))")
-            } else {
-                Text("Play \(mediaSource.name)")
-            }
-        }
-        .focused($focus, equals: .play)
-    }
-}
-
 // MARK: Play button
 fileprivate struct PlayNavigationView: View {
     private let media: any MediaProtocol
@@ -503,58 +471,6 @@ fileprivate struct PlayNavigationView: View {
             }
             .accessibilityLabel("Play button menu")
             .focused($focus, equals: .play)
-        }
-    }
-}
-
-// MARK: Episode play buttons
-fileprivate struct TVEpisodeNavigationView: View {
-    let seasons: [any TVSeasonProtocol]
-    let streamingService: any StreamingServiceProtocol
-    let episode: any TVEpisodeProtocol
-    let media: any MediaProtocol
-    
-    @FocusState.Binding var focus: ButtonType?
-    @Binding var navigation: NavigationPath
-    
-    var body: some View {
-        if let mediaSource = episode.mediaSources.first {
-            // Always restart episode button
-            Button {
-                navigation.append(
-                    PlayerViewModel(
-                        media: media,
-                        mediaSource: mediaSource,
-                        startTime: .zero,
-                        streamingService: streamingService,
-                        seasons: seasons
-                    )
-                )
-            } label: {
-                Text("\(mediaSource.startTicks == 0 ? "Play" : "Restart") \(episode.title)")
-            }
-            .focused($focus, equals: .play)
-            
-            // If the next episode to play already has progress
-            if mediaSource.startTicks != 0 {
-                Button {
-                    navigation.append(
-                        PlayerViewModel(
-                            media: media,
-                            mediaSource: mediaSource,
-                            startTime: CMTimeMakeWithSeconds(Double(mediaSource.startTicks / 10_000_000), preferredTimescale: 1),
-                            streamingService: streamingService,
-                            seasons: seasons
-                        )
-                    )
-                } label: {
-                    Text("Resume \(episode.title)")
-                }
-                .focused($focus, equals: .play)
-            }
-        } else {
-            Text("Error loading episode")
-                .foregroundStyle(.red)
         }
     }
 }

--- a/Stingray/DetailMediaView.swift
+++ b/Stingray/DetailMediaView.swift
@@ -402,7 +402,7 @@ fileprivate struct PlayNavigationView: View {
                         seasons: self.seasons
                     )
                 )
-            } label: { Label(mediaSource.name, systemImage: "play.fill") }
+            } label: { Label(self.title, systemImage: "play.fill") }
                 .focused($focus, equals: .play)
         }
         // If there are multiple sources but all unwatched, show only "play" options that start from beginning

--- a/Stingray/DetailMediaView.swift
+++ b/Stingray/DetailMediaView.swift
@@ -453,7 +453,6 @@ fileprivate struct PlayNavigationView: View {
                         )
                     } label: {
                         Label(mediaSource.name, systemImage: "play.fill")
-                        Text("Start from \(String(ticks: mediaSource.startTicks))")
                     }
                 }
             }

--- a/Stingray/PlayerViewModel.swift
+++ b/Stingray/PlayerViewModel.swift
@@ -129,24 +129,28 @@ final class PlayerViewModel: Hashable {
         
         var title = ""
         var subtitle = ""
-        if let seasons = self.seasons { // TV Shows
-            for season in seasons {
-                if let episode = (season.episodes.first { $0.mediaSources.first?.id == mediaSource.id }) {
-                    subtitle = "Season \(season.seasonNumber), Episode \(episode.episodeNumber)"
-                    break
+        
+        switch self.media.mediaType {
+        case .tv(let seasons):
+            if let seasons = seasons { // TV Shows
+                for season in seasons {
+                    if let episode = (season.episodes.first { $0.mediaSources.first?.id == self.mediaSource.id }) {
+                        subtitle = "Season \(season.seasonNumber), Episode \(episode.episodeNumber)"
+                        break
+                    }
                 }
+                let allEpisodes = seasons.flatMap(\.episodes)
+                let currentEpisode = allEpisodes.first { $0.mediaSources.first?.id == self.mediaSource.id }
+                title = currentEpisode?.title ?? ""
             }
-            
-            let allEpisodes = seasons.flatMap(\.episodes)
-            let currentEpisode = allEpisodes.first { $0.mediaSources.first?.id == mediaSource.id }
-            title = currentEpisode?.title ?? ""
-        }
-        else { // Movies
-            title = mediaSource.name
+            else { title = self.mediaSource.name }
+        case .movies(let sources):
+            title = self.media.title
+        default: title = self.media.title
         }
         
         guard let player = streamingService.playbackStart(
-            mediaSource: mediaSource,
+            mediaSource: self.mediaSource,
             videoID: videoID ?? self.playerProgress?.videoID ?? "0",
             audioID: audioID ?? self.playerProgress?.audioID ?? "1",
             subtitleID: subtitleID ?? self.playerProgress?.subtitleID, // nil is no subtitles

--- a/Stingray/PlayerViewModel.swift
+++ b/Stingray/PlayerViewModel.swift
@@ -146,6 +146,7 @@ final class PlayerViewModel: Hashable {
             else { title = self.mediaSource.name }
         case .movies(let sources):
             title = self.media.title
+            if sources.count > 1 { subtitle = self.mediaSource.name }
         default: title = self.media.title
         }
         


### PR DESCRIPTION
Replace the play button sometimes to offer multiple variants:

|   | Single Version of Media | Multiple Versions of Media |
| - | ----------------------- | -------------------------- |
| Watched None | ![single unwatched](https://github.com/user-attachments/assets/c130dfc4-50f1-4773-9ed7-43651d7d45c8) | ![multiple unwatched](https://github.com/user-attachments/assets/4074dacd-3a90-4c3f-83ef-c68730752b95) |
| Watched Some | ![single continue](https://github.com/user-attachments/assets/2bba3980-d83c-4c8b-931b-76e073d82d54) | ![multiple continue](https://github.com/user-attachments/assets/b058cd13-1f72-458a-90a4-e491751b4130) |

This implementation always presents the most number of options available to the user, and skips the menu or shrinks the menu when possible. This unifies the `DetailMediaView`'s appearance between TV shows and movies.

Other implementations were considered, like a long-press, however this proved to not be as intuitive as shown by comments about people not knowing how to sign out of Stingray. Further small tests were conducted among colleagues with other applications and they similarly were unaware of long-pressing on buttons in apps.