### PR TITLE
Reduce Media Error Scope to Individual Media

### DIFF
--- a/Stingray.xcodeproj/project.pbxproj
+++ b/Stingray.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 				APIs/APIBasicNetwork.swift,
 				APIs/APIStorage.swift,
 				APIs/APIUserStorage.swift,
+				Models/DecoderExtension.swift,
 				Models/MediaModel.swift,
 				Models/RError.swift,
 				Models/StreamingServiceBasicModel.swift,

--- a/Stingray/ErrorView.swift
+++ b/Stingray/ErrorView.swift
@@ -24,7 +24,7 @@ public struct ErrorView: View {
             .buttonStyle(.plain)
             .padding(.horizontal, 70)
             .focused($isFocused, equals: true)
-            .sheet(isPresented: $isExpanded) { ErrorExpandedView(error: error) }
+            .sheet(isPresented: $isExpanded) { ErrorExpandedView(errorDesc: error.rDescription) }
     }
 }
 
@@ -53,12 +53,12 @@ fileprivate struct ErrorSummaryView: View {
 /// Show a verbose version of an RError
 public struct ErrorExpandedView: View {
     /// Verbose error thrown by Stingray
-    let error: RError
+    let errorDesc: () -> String
     
     public var body: some View {
         VStack(alignment: .leading) {
             Text("Error:")
-            Text(error.rDescription())
+            Text(errorDesc())
         }
         .padding(.horizontal, 50)
         .padding(.vertical, 20)
@@ -72,6 +72,6 @@ public struct ErrorExpandedView: View {
 #Preview {
     ErrorSummaryView(summary: "Stingray went kaplooey.", altColors: false)
         .sheet(isPresented: .constant(true)) {
-            ErrorExpandedView(error: NetworkError.decodeJSONFailed(JSONError.missingKey("Nerd", "Preview"), url: nil))
+            ErrorExpandedView(errorDesc: NetworkError.decodeJSONFailed(JSONError.missingKey("Nerd", "Preview"), url: nil).rDescription)
         }
 }

--- a/Stingray/ErrorView.swift
+++ b/Stingray/ErrorView.swift
@@ -51,11 +51,11 @@ fileprivate struct ErrorSummaryView: View {
 }
 
 /// Show a verbose version of an RError
-fileprivate struct ErrorExpandedView: View {
+public struct ErrorExpandedView: View {
     /// Verbose error thrown by Stingray
     let error: RError
     
-    var body: some View {
+    public var body: some View {
         VStack(alignment: .leading) {
             Text("Error:")
             Text(error.rDescription())

--- a/Stingray/HomeView.swift
+++ b/Stingray/HomeView.swift
@@ -152,13 +152,7 @@ fileprivate struct MediaNavigation: View {
     @Binding var navigation: NavigationPath
     
     var body: some View {
-        Button {
-            navigation.append(media)
-        } label: {
-            MediaCard(media: media, streamingService: streamingService)
-                .frame(width: 200, height: 370)
-        }
-        .buttonStyle(.card)
+        MediaCard(media: media, streamingService: streamingService) { navigation.append(media) }
     }
 }
 

--- a/Stingray/HomeView.swift
+++ b/Stingray/HomeView.swift
@@ -138,21 +138,10 @@ fileprivate struct MediaPicker: View {
         ScrollView(.horizontal) {
             HStack {
                 ForEach(pickerMedia) { media in
-                    MediaNavigation(media: media, streamingService: streamingService, navigation: $navigation)
+                    MediaCard(media: media, streamingService: streamingService) { navigation.append(media) }
                 }
             }
         }
-    }
-}
-
-fileprivate struct MediaNavigation: View {
-    var media: SlimMedia
-    var streamingService: StreamingServiceProtocol
-    
-    @Binding var navigation: NavigationPath
-    
-    var body: some View {
-        MediaCard(media: media, streamingService: streamingService) { navigation.append(media) }
     }
 }
 

--- a/Stingray/LibraryView.swift
+++ b/Stingray/LibraryView.swift
@@ -39,9 +39,7 @@ public struct LibraryView: View {
 }
 
 public struct MediaGridView: View {
-    private let cardWidth = 200.0
-    private let cardHeight = 370.0
-    private let cardSpacing = 50.0
+    static let cardSpacing = 50.0
     let allMedia: [any MediaProtocol]
     let streamingService: any StreamingServiceProtocol
     
@@ -49,17 +47,11 @@ public struct MediaGridView: View {
     
     public var body: some View {
         let columns = [
-            GridItem(.adaptive(minimum: cardWidth, maximum: cardWidth), spacing: cardSpacing)
+            GridItem(.adaptive(minimum: MediaCard.cardSize.width, maximum: MediaCard.cardSize.height), spacing: Self.cardSpacing)
         ]
-        LazyVGrid(columns: columns, spacing: cardSpacing) {
+        LazyVGrid(columns: columns, spacing: Self.cardSpacing) {
             ForEach(allMedia, id: \.id) { media in
-                Button {
-                    navigation.append(AnyMedia(media: media))
-                } label: {
-                    MediaCard(media: media, streamingService: streamingService)
-                        .frame(width: cardWidth, height: cardHeight)
-                }
-                .buttonStyle(.card)
+                MediaCard(media: media, streamingService: streamingService) { navigation.append(AnyMedia(media: media)) }
             }
         }
     }

--- a/Stingray/MediaCardView.swift
+++ b/Stingray/MediaCardView.swift
@@ -46,6 +46,11 @@ struct MediaCard: View {
                 .padding(.top, 5)
             Spacer()
         }
+        .background {
+            if !(self.media.errors?.isEmpty ?? true) {
+                Color.red.opacity(0.25)
+            }
+        }
         .id(media.id) // Stabilize view identity
     }
 }

--- a/Stingray/MediaCardView.swift
+++ b/Stingray/MediaCardView.swift
@@ -23,7 +23,9 @@ struct MediaCard: View {
     }
     
     var body: some View {
-        Button { action() }
+        Button {
+            if self.media.errors == nil { action() }
+        }
         label: {
             VStack(spacing: 0) {
                 if media.imageTags.primary != nil {

--- a/Stingray/MediaCardView.swift
+++ b/Stingray/MediaCardView.swift
@@ -69,7 +69,7 @@ struct MediaCard: View {
         .buttonStyle(.card)
         .contextMenu {
             if self.media.errors != nil {
-                Button("Show Error", systemImage: "exclamationmark.circle", role: .destructive) { self.showError = true }
+                Button("Show Error", systemImage: "exclamationmark.octagon", role: .destructive) { self.showError = true }
             }
         }
         .sheet(isPresented: $showError) {

--- a/Stingray/MediaCardView.swift
+++ b/Stingray/MediaCardView.swift
@@ -11,46 +11,60 @@ import SwiftUI
 struct MediaCard: View {
     let media: any SlimMediaProtocol
     let url: URL?
+    let action: @MainActor () -> Void
     
-    init(media: any SlimMediaProtocol, streamingService: StreamingServiceProtocol) {
+    static let cardSize = CGSize(width: 200, height: 370)
+    static let imageHeight = Self.cardSize.height - 85
+    
+    init(media: any SlimMediaProtocol, streamingService: StreamingServiceProtocol, action: @escaping @MainActor () -> Void) {
         self.media = media
         self.url = streamingService.getImageURL(imageType: .primary, mediaID: media.id, width: 400)
+        self.action = action
     }
     
     var body: some View {
-        VStack(spacing: 0) {
-            if media.imageTags.primary != nil {
-                AsyncImage(url: url) { image in
-                    image
-                        .resizable()
-                        .scaledToFill()
-                } placeholder: {
-                    if let blurHash = media.imageBlurHashes?.getBlurHash(for: .primary),
-                       let blurImage = UIImage(blurHash: blurHash, size: .init(width: 32, height: 32)) {
-                        Image(uiImage: blurImage)
+        Button { action() }
+        label: {
+            VStack(spacing: 0) {
+                if media.imageTags.primary != nil {
+                    AsyncImage(url: url) { image in
+                        image
                             .resizable()
                             .scaledToFill()
-                            .accessibilityHint("Temporary placeholder for missing image", isEnabled: false)
-                    } else {
-                        MediaCardLoading()
+                            .frame(width: Self.cardSize.width, height: 285)
+                            .clipped()
+                    } placeholder: {
+                        if let blurHash = media.imageBlurHashes?.getBlurHash(for: .primary),
+                           let blurImage = UIImage(blurHash: blurHash, size: .init(width: 32, height: 32)) {
+                            Image(uiImage: blurImage)
+                                .resizable()
+                                .scaledToFill()
+                                .accessibilityHint("Temporary placeholder for missing image", isEnabled: false)
+                                .frame(width: Self.cardSize.width, height: 285)
+                                .clipped()
+                        } else {
+                            MediaCardLoading()
+                        }
                     }
+                } else {
+                    MediaCardNoImage()
                 }
-            } else {
-                MediaCardNoImage()
+                Text(media.title)
+                    .multilineTextAlignment(.center)
+                    .lineLimit(2)
+                    .truncationMode(.tail)
+                    .padding(.horizontal, 5)
+                    .padding(.top, 5)
+                Spacer(minLength: 0)
             }
-            Text(media.title)
-                .multilineTextAlignment(.center)
-                .lineLimit(2)
-                .truncationMode(.tail)
-                .padding(.horizontal, 5)
-                .padding(.top, 5)
-            Spacer()
-        }
-        .background {
-            if !(self.media.errors?.isEmpty ?? true) {
-                Color.red.opacity(0.25)
+            .background {
+                if !(self.media.errors?.isEmpty ?? true) {
+                    Color.red.opacity(0.25)
+                }
             }
         }
+        .buttonStyle(.card)
+        .frame(width: Self.cardSize.width, height: Self.cardSize.height)
         .id(media.id) // Stabilize view identity
     }
 }

--- a/Stingray/MediaCardView.swift
+++ b/Stingray/MediaCardView.swift
@@ -12,6 +12,7 @@ struct MediaCard: View {
     let media: any SlimMediaProtocol
     let url: URL?
     let action: @MainActor () -> Void
+    @State var showError: Bool = false
     
     static let cardSize = CGSize(width: 200, height: 370)
     static let imageHeight = Self.cardSize.height - 85
@@ -66,6 +67,16 @@ struct MediaCard: View {
             }
         }
         .buttonStyle(.card)
+        .contextMenu {
+            if self.media.errors != nil {
+                Button("Show Error", systemImage: "exclamationmark.circle", role: .destructive) { self.showError = true }
+            }
+        }
+        .sheet(isPresented: $showError) {
+            if let errors = self.media.errors {
+                ErrorExpandedView(errorDesc: errors.rDescription)
+            }
+        }
         .frame(width: Self.cardSize.width, height: Self.cardSize.height)
         .id(media.id) // Stabilize view identity
     }

--- a/Stingray/Models/DecoderExtension.swift
+++ b/Stingray/Models/DecoderExtension.swift
@@ -1,0 +1,37 @@
+//
+//  DecoderExtension.swift
+//  Stingray
+//
+//  Created by Ben Roberts on 1/28/26.
+//
+
+import Foundation
+
+/// An extension to offer safer alternatives to decoding
+extension KeyedDecodingContainer {
+    /// Decoding made safe.
+    /// - Parameters:
+    ///   - type: Type to decode to
+    ///   - key: JSON key to decode
+    ///   - defaultValue: Fallback value to use if unable to decode
+    ///   - errBucket: Bucket to append errors to
+    ///   - errLabel: Label denoting the object which owns this key
+    /// - Returns: The decoded value for the given key, if possible
+    func decodeFieldSafely<T: Decodable>(
+        _ type: T.Type,
+        forKey key: Key,
+        default defaultValue: T,
+        errBucket: inout [RError],
+        errLabel: String
+    ) -> T {
+        do { return try decodeIfPresent(type, forKey: key) ?? { throw JSONError.missingKey(key.description, errLabel) }() }
+        catch let error as JSONError { // Missing key
+            errBucket.append(error)
+            return defaultValue
+        }
+        catch { // Generic JSON decode error
+            errBucket.append(JSONError.failedJSONDecode(key.description, error))
+            return defaultValue
+        }
+    }
+}

--- a/Stingray/Models/DecoderExtension.swift
+++ b/Stingray/Models/DecoderExtension.swift
@@ -16,15 +16,22 @@ extension KeyedDecodingContainer {
     ///   - defaultValue: Fallback value to use if unable to decode
     ///   - errBucket: Bucket to append errors to
     ///   - errLabel: Label denoting the object which owns this key
+    ///   - required: The field is a required field, and will add an error if missing. Default is true
     /// - Returns: The decoded value for the given key, if possible
     func decodeFieldSafely<T: Decodable>(
         _ type: T.Type,
         forKey key: Key,
         default defaultValue: T,
         errBucket: inout [RError],
-        errLabel: String
+        errLabel: String,
+        required: Bool = true,
     ) -> T {
-        do { return try decodeIfPresent(type, forKey: key) ?? { throw JSONError.missingKey(key.description, errLabel) }() }
+        do {
+            return try decodeIfPresent(type, forKey: key) ?? {
+                if required { throw JSONError.missingKey(key.description, errLabel) }
+                return defaultValue
+            }()
+        }
         catch let error as JSONError { // Missing key
             errBucket.append(error)
             return defaultValue

--- a/Stingray/Models/MediaModel.swift
+++ b/Stingray/Models/MediaModel.swift
@@ -415,6 +415,8 @@ public final class SlimMedia: SlimMediaProtocol, Decodable {
             errLabel: "Slim Media",
             required: false
         )
+        
+        if !errBucket.isEmpty { errors = errBucket } // Otherwise nil
     }
     
     // Hashable conformance

--- a/Stingray/Models/MediaModel.swift
+++ b/Stingray/Models/MediaModel.swift
@@ -206,7 +206,8 @@ public final class MediaModel: MediaProtocol, Decodable {
             forKey: .description,
             default: "",
             errBucket: &errBucket,
-            errLabel: "Media Model"
+            errLabel: "Media Model",
+            required: false
         )
         
         imageTags = container.decodeFieldSafely(
@@ -214,7 +215,8 @@ public final class MediaModel: MediaProtocol, Decodable {
             forKey: .imageTags,
             default: MediaImages(thumbnail: nil, logo: nil, primary: nil),
             errBucket: &errBucket,
-            errLabel: "Media Model"
+            errLabel: "Media Model",
+            required: false
         )
         
         imageBlurHashes = container.decodeFieldSafely(
@@ -222,7 +224,8 @@ public final class MediaModel: MediaProtocol, Decodable {
             forKey: .imageBlurHashes,
             default: nil,
             errBucket: &errBucket,
-            errLabel: "Media Model"
+            errLabel: "Media Model",
+            required: false
         )
         
         genres = container.decodeFieldSafely(
@@ -230,7 +233,8 @@ public final class MediaModel: MediaProtocol, Decodable {
             forKey: .genres,
             default: [],
             errBucket: &errBucket,
-            errLabel: "Media Model"
+            errLabel: "Media Model",
+            required: false
         )
         
         maturity = container.decodeFieldSafely(
@@ -238,7 +242,8 @@ public final class MediaModel: MediaProtocol, Decodable {
             forKey: .maturity,
             default: nil,
             errBucket: &errBucket,
-            errLabel: "Media Model"
+            errLabel: "Media Model",
+            required: false
         )
         
         let mediaType = container.decodeFieldSafely(
@@ -246,7 +251,8 @@ public final class MediaModel: MediaProtocol, Decodable {
             forKey: .mediaType,
             default: .unknown,
             errBucket: &errBucket,
-            errLabel: "Media Model"
+            errLabel: "Media Model",
+            required: false
         )
         switch mediaType {
         case .movies:
@@ -273,7 +279,8 @@ public final class MediaModel: MediaProtocol, Decodable {
                 forKey: .userData,
                 default: UserData(playbackPositionTicks: .zero, mediaItemID: UUID().uuidString),
                 errBucket: &errBucket,
-                errLabel: "Media Model"
+                errLabel: "Media Model",
+                required: false
             )
             if let defaultIndex = movieSources.firstIndex(where: { $0.id == userDataContainer.mediaItemID }) {
                 movieSources[defaultIndex].startTicks = userDataContainer.playbackPositionTicks
@@ -288,7 +295,8 @@ public final class MediaModel: MediaProtocol, Decodable {
             forKey: .duration,
             default: nil,
             errBucket: &errBucket,
-            errLabel: "Media Model"
+            errLabel: "Media Model",
+            required: false
         )
         if let runtimeTicks = runtimeTicks, runtimeTicks != 0 { duration = .nanoseconds(100 * runtimeTicks) }
         else { duration = nil }
@@ -298,7 +306,8 @@ public final class MediaModel: MediaProtocol, Decodable {
             forKey: .releaseDate,
             default: nil,
             errBucket: &errBucket,
-            errLabel: "Media Model"
+            errLabel: "Media Model",
+            required: false
         ) {
             let formatter = ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
@@ -310,7 +319,8 @@ public final class MediaModel: MediaProtocol, Decodable {
             forKey: .people,
             default: [],
             errBucket: &errBucket,
-            errLabel: "Media Model"
+            errLabel: "Media Model",
+            required: false
         )
         
         if !errBucket.isEmpty { errors = errBucket } // Otherwise nil
@@ -379,7 +389,8 @@ public final class SlimMedia: SlimMediaProtocol, Decodable {
             forKey: .imageBlurHashes,
             default: nil,
             errBucket: &errBucket,
-            errLabel: "Slim Media"
+            errLabel: "Slim Media",
+            required: false
         )
         
         self.imageTags = container.decodeFieldSafely(
@@ -387,7 +398,8 @@ public final class SlimMedia: SlimMediaProtocol, Decodable {
             forKey: .imageTags,
             default: MediaImages(thumbnail: nil, logo: nil, primary: nil),
             errBucket: &errBucket,
-            errLabel: "Slim Media"
+            errLabel: "Slim Media",
+            required: false
         )
     }
     

--- a/Stingray/Models/MediaModel.swift
+++ b/Stingray/Models/MediaModel.swift
@@ -362,8 +362,15 @@ public final class SlimMedia: SlimMediaProtocol, Decodable {
         
         self.id = container.decodeFieldSafely(
             String.self,
-            forKey: .id,
-            default: UUID().uuidString,
+            forKey: .seriesID,
+            default: container.decodeFieldSafely(
+                String.self,
+                forKey: .id,
+                default: UUID().uuidString,
+                errBucket: &errBucket,
+                errLabel: "Slim Media",
+                required: false
+            ),
             errBucket: &errBucket,
             errLabel: "Slim Media"
         )
@@ -378,8 +385,15 @@ public final class SlimMedia: SlimMediaProtocol, Decodable {
         
         self.title = container.decodeFieldSafely(
             String.self,
-            forKey: .title,
-            default: "Unknown title",
+            forKey: .seriesTitle,
+            default: container.decodeFieldSafely(
+                String.self,
+                forKey: .title,
+                default: "Unknown Title",
+                errBucket: &errBucket,
+                errLabel: "Slim Media",
+                required: false
+            ),
             errBucket: &errBucket,
             errLabel: "Slim Media"
         )

--- a/Stingray/Models/MediaModel.swift
+++ b/Stingray/Models/MediaModel.swift
@@ -587,6 +587,7 @@ public enum MediaType: Decodable {
     case collections
     case movies([any MediaSourceProtocol])
     case tv([TVSeason]?)
+    case unknown
     
     public init (from decoder: Decoder) throws(JSONError) {
         let container: any SingleValueDecodingContainer
@@ -623,6 +624,8 @@ public enum MediaType: Decodable {
             return "Movie"
         case .tv:
             return "Series"
+        case .unknown:
+            return "Unknown"
         }
     }
 }

--- a/Stingray/Models/MediaModel.swift
+++ b/Stingray/Models/MediaModel.swift
@@ -185,7 +185,7 @@ public final class MediaModel: MediaProtocol, Decodable {
             
             id = try container.decode(String.self, forKey: .id)
             
-            genres = try container.decode([String].self, forKey: .genres)
+            genres = try container.decodeIfPresent([String].self, forKey: .genres) ?? []
             
             maturity = try container.decodeIfPresent(String.self, forKey: .maturity)
             

--- a/Stingray/Models/RError.swift
+++ b/Stingray/Models/RError.swift
@@ -41,6 +41,17 @@ extension RError {
     }
 }
 
+/// Extend arrays of `RError` to provide recursive descriptions formatted in a reasonable manner.
+extension [RError] {
+    /// Recursive description. Prints this error's description and all subsequent ones.
+    /// - Returns: Formatted description.
+    public func rDescription() -> String {
+        return self.reduce("") { (result, error) -> String in
+            return result + "\n\t\t→ \(error.errorDescription)"
+        }
+    }
+}
+
 // MARK: Error Implementations
 
 public enum NetworkError: RError {

--- a/Stingray/Models/RError.swift
+++ b/Stingray/Models/RError.swift
@@ -47,7 +47,7 @@ extension [RError] {
     /// - Returns: Formatted description.
     public func rDescription() -> String {
         return self.reduce("") { (result, error) -> String in
-            return result + "\n\t\t→ \(error.errorDescription)"
+            return result + "\n\t→ \(error.errorDescription)"
         }
     }
 }

--- a/Stingray/PlayerView.swift
+++ b/Stingray/PlayerView.swift
@@ -254,7 +254,7 @@ fileprivate struct PlayerDescriptionView: View {
                 .modifier(MaterialEffectModifier())
                 
                 switch media.mediaType {
-                case .collections, .movies:
+                case .collections, .movies, .unknown:
                     EmptyView()
                 case .tv(let seasons):
                     if let seasons = seasons,

--- a/Stingray/PlayerViewModel.swift
+++ b/Stingray/PlayerViewModel.swift
@@ -18,7 +18,7 @@ final class PlayerViewModel: Hashable {
     public var mediaSourceID: String {
         didSet {
             switch self.media.mediaType {
-            case .collections:
+            case .collections, .unknown:
                 break
             case .movies(let mediaSources):
                 self.mediaSource = mediaSources.first { $0.id == self.mediaSourceID } ?? self.mediaSource


### PR DESCRIPTION
A single `MediaModel` or `SlimMediaModel` is now very unlikely to prevent a library from loading. Instead, the library now displays the errored media with the option to display the error, and this is accomplished by wrapping `KeyedDecodingContainer.decodeIfPresent` with `decodeFieldSafely`. The new `decodeFieldSafely` method requires a default value and can be marked as required. Required fields add an error to an "error bucket", which is then saved with the the media, and is able to be read by other views and view models.

The `MediaCard` is able to read errors from participating models to display media cards in red, and removes the ability to navigate to that media.
![Errors](https://github.com/user-attachments/assets/e9652659-4f69-441e-8d62-b2a8c35aace2)

Other small tweaks were made as well:
- Posters now take up more of the available media card.
- Media cards now handle the usual button actions.
  - Gained a context menu for displaying errors.