### PR TITLE
Correct Specials Placement

### DIFF
--- a/Stingray/APIs/APINetwork.swift
+++ b/Stingray/APIs/APINetwork.swift
@@ -420,7 +420,6 @@ final class JellyfinAdvancedNetwork: AdvancedNetworkProtocol {
                                 id: seasonID,
                                 title: try episodeContainer.decode(String.self, forKey: .seasonTitle),
                                 episodes: [episode],
-                                seasonNumber: try episodeContainer.decodeIfPresent(Int.self, forKey: .seasonNumber) ?? 1
                             )
                             tempSeasons.append(newSeason)
                         }

--- a/Stingray/APIs/APINetwork.swift
+++ b/Stingray/APIs/APINetwork.swift
@@ -416,7 +416,6 @@ final class JellyfinAdvancedNetwork: AdvancedNetworkProtocol {
                         let seasonTitle = try episodeContainer.decodeIfPresent(String.self, forKey: .seasonTitle) ?? "Unknown Season"
                         if seasonTitle == "Specials" { // Episode is a special
                             let newSeason = TVSeason(
-                                id: UUID().uuidString, // Create a dummy ID since a single episode doesn't really have a unique season
                                 title: "Special",
                                 episodes: [episode]
                             )
@@ -427,8 +426,7 @@ final class JellyfinAdvancedNetwork: AdvancedNetworkProtocol {
                         }
                         else { // Episode needs a new season
                             let newSeason = TVSeason(
-                                id: seasonID,
-                                title: try episodeContainer.decode(String.self, forKey: .seasonTitle),
+                                title: try episodeContainer.decodeIfPresent(String.self, forKey: .seasonTitle) ?? "Unknown Season",
                                 episodes: [episode],
                             )
                             tempSeasons.append(newSeason)

--- a/Stingray/APIs/APINetwork.swift
+++ b/Stingray/APIs/APINetwork.swift
@@ -424,7 +424,8 @@ final class JellyfinAdvancedNetwork: AdvancedNetworkProtocol {
                         }
                         else if let seasonIndex = tempSeasons.firstIndex(where: { $0.id == seasonID }) { // Episode is in an existing eason
                             tempSeasons[seasonIndex].episodes.append(episode)
-                        } else { // Episode needs a new season
+                        }
+                        else { // Episode needs a new season
                             let newSeason = TVSeason(
                                 id: seasonID,
                                 title: try episodeContainer.decode(String.self, forKey: .seasonTitle),

--- a/Stingray/DetailMediaView.swift
+++ b/Stingray/DetailMediaView.swift
@@ -514,9 +514,8 @@ fileprivate struct SeasonSelectorView: View {
                         self.focus = .media(firstEpisode.id)
                     }
                 }
-            } label: {
-                Text("Season \(season.seasonNumber)")
             }
+            label: { Text(season.title) }
             .padding(16)
             .background {
                 if season.id == lastFocusedSeasonID {
@@ -630,7 +629,7 @@ fileprivate struct EpisodeView: View {
                     // Season and episode number
                     HStack(spacing: 0) {
                         if let season = (seasons.first { $0.episodes.contains { $0.id == episode.id } }) {
-                            Text("Season \(season.seasonNumber), ")
+                            Text("\(season.title), ")
                         }
                         Text("Episode \(episode.episodeNumber)")
                         Spacer()

--- a/Stingray/Models/MediaModel.swift
+++ b/Stingray/Models/MediaModel.swift
@@ -97,6 +97,7 @@ public protocol MediaStreamProtocol: Identifiable {
 }
 
 public protocol TVSeasonProtocol: Identifiable {
+    /// A generic ID - Not relevant to the ID of the season set by the server
     var id: String { get }
     var title: String { get }
     var episodes: [any TVEpisodeProtocol] { get }
@@ -480,8 +481,8 @@ public final class TVSeason: TVSeasonProtocol {
     public var title: String
     public var episodes: [any TVEpisodeProtocol]
     
-    public init(id: String, title: String, episodes: [any TVEpisodeProtocol]) {
-        self.id = id
+    public init(title: String, episodes: [any TVEpisodeProtocol]) {
+        self.id = UUID().uuidString
         self.title = title
         self.episodes = episodes
     }

--- a/Stingray/Models/MediaModel.swift
+++ b/Stingray/Models/MediaModel.swift
@@ -100,7 +100,6 @@ public protocol TVSeasonProtocol: Identifiable {
     var id: String { get }
     var title: String { get }
     var episodes: [any TVEpisodeProtocol] { get }
-    var seasonNumber: Int { get }
 }
 
 public protocol TVEpisodeProtocol: Displayable {
@@ -480,13 +479,11 @@ public final class TVSeason: TVSeasonProtocol {
     public var id: String
     public var title: String
     public var episodes: [any TVEpisodeProtocol]
-    public var seasonNumber: Int
     
-    public init(id: String, title: String, episodes: [any TVEpisodeProtocol], seasonNumber: Int) {
+    public init(id: String, title: String, episodes: [any TVEpisodeProtocol]) {
         self.id = id
         self.title = title
         self.episodes = episodes
-        self.seasonNumber = seasonNumber
     }
 }
 

--- a/Stingray/PlayerViewModel.swift
+++ b/Stingray/PlayerViewModel.swift
@@ -136,7 +136,7 @@ final class PlayerViewModel: Hashable {
             if let seasons = seasons { // TV Shows
                 for season in seasons {
                     if let episode = (season.episodes.first { $0.mediaSources.first?.id == self.mediaSource.id }) {
-                        subtitle = "Season \(season.seasonNumber), Episode \(episode.episodeNumber)"
+                        subtitle = "\(season.title), Episode \(episode.episodeNumber)"
                         break
                     }
                 }


### PR DESCRIPTION
Specials are now placed where they belong, before, after, and inside seasons are supported. Specials now appear in the season selector as "Special," which can break a season into parts, labeling the split portions as "Season X Cont."

![Screenshot 2026-02-05 at 11 12 16 AM](https://github.com/user-attachments/assets/169c0a44-c72c-4f2c-8c06-d5aaf1672721)

Another small change is that the season title is used instead of the season number. This is because the season title is already correctly formed by Jellyfin, and allows for easy manipulation of the title during the init.