### PR TITLE
Only pass vm to AVPlayerViewControllerRepresentable

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Extensive content metadata.
   - [ ] Set PINs for certain profiles
 - [x] Extend playback buffer
 - [x] Lower priority of downloading media
+- [x] Use the same view model across all player views
 
 ### Long Shots
 


### PR DESCRIPTION
Functions continue to exist due to their ability to create side effects. Values are passed to the coordinator since they need a copy for PiP identification.