### PR TITLE
Fix subtitle display and HDR track switching

### DIFF
--- a/Stingray/APIs/APINetwork.swift
+++ b/Stingray/APIs/APINetwork.swift
@@ -54,6 +54,7 @@ public protocol AdvancedNetworkProtocol {
     ///   - contentID: The media source ID
     ///   - bitrate: Target video bitrate in bits per second
     ///   - subtitleID: Subtitles to be used (nil for none)
+    ///   - subtitleCodec: Codec of the selected subtitle stream (e.g. "srt", "ass", "pgssub")
     ///   - audioID: Audio ID to be used
     ///   - videoID: Video ID to be used
     ///   - sessionID: A one-off token to not be reused when changing settings
@@ -65,6 +66,7 @@ public protocol AdvancedNetworkProtocol {
         contentID: String,
         bitrate: Int,
         subtitleID: String?,
+        subtitleCodec: String?,
         audioID: String,
         videoID: String,
         sessionID: String,
@@ -427,6 +429,7 @@ final class JellyfinAdvancedNetwork: AdvancedNetworkProtocol {
         contentID: String,
         bitrate: Int,
         subtitleID: String?,
+        subtitleCodec: String? = nil,
         audioID: String,
         videoID: String,
         sessionID: String,
@@ -439,7 +442,7 @@ final class JellyfinAdvancedNetwork: AdvancedNetworkProtocol {
             URLQueryItem(name: "mediaSourceID", value: contentID),
             URLQueryItem(name: "audioStreamIndex", value: String(audioID)),
             URLQueryItem(name: "videoStreamIndex", value: String(videoID)),
-            
+
             // Video config
             URLQueryItem(name: "videoBitRate", value: String(bitrate)),
             URLQueryItem(name: "videoCodec", value: "hevc,h264"),
@@ -453,12 +456,12 @@ final class JellyfinAdvancedNetwork: AdvancedNetworkProtocol {
             URLQueryItem(name: "hevc-codectag", value: "hvc1,dvh1"),
             URLQueryItem(name: "deInterlace", value: "true"),
             URLQueryItem(name: "h265-codectag", value: "hvc1,dvh1,dvhe"),
-            
+
             // Audio config
             URLQueryItem(name: "audioCodec", value: "aac,ac3,eac3,alac,mp3"),
             URLQueryItem(name: "allowAudioStreamCopy", value: "true"),
             URLQueryItem(name: "enableAudioVbrEncoding", value: "true"),
-            
+
             // Streaming config
             URLQueryItem(name: "breakOnNonKeyFrames", value: "true"),
             URLQueryItem(name: "requireAVC", value: "false"),
@@ -466,12 +469,26 @@ final class JellyfinAdvancedNetwork: AdvancedNetworkProtocol {
             URLQueryItem(name: "copyTimestamps", value: "true"),
             URLQueryItem(name: "enableAutoStreamCopy", value: "true")
         ]
-        
+
         if let subtitleID = subtitleID {
-            params.append(URLQueryItem(name: "SubtitleMethod", value: "Encode"))
-            params.append(URLQueryItem(name: "subtitleStreamIndex", value: String(subtitleID)))
+            // Only include subtitle params for image-based subtitles that require burn-in.
+            // Text-based subtitles (SRT, ASS, VTT) are handled client-side via VTT overlay
+            // to avoid HLS subtitle sync issues and unnecessary transcoding.
+            let needsBurnIn: Bool
+            if let codec = subtitleCodec?.lowercased() {
+                let imageBasedCodecs = ["pgssub", "pgs", "dvdsub", "vobsub", "sub", "dvbsub", "dvb_subtitle", "xsub"]
+                needsBurnIn = imageBasedCodecs.contains(codec)
+            } else {
+                needsBurnIn = true // Unknown codec — use burn-in as fallback
+            }
+
+            if needsBurnIn {
+                params.append(URLQueryItem(name: "SubtitleMethod", value: "Encode"))
+                params.append(URLQueryItem(name: "subtitleStreamIndex", value: String(subtitleID)))
+            }
+            // Text subtitles: no params in URL — rendered by client VTT overlay
         }
-        
+
         guard let item = self.buildAVPlayerItem(
             path: "/Videos/\(contentID)/main.m3u8",
             urlParams: params,

--- a/Stingray/APIs/APINetwork.swift
+++ b/Stingray/APIs/APINetwork.swift
@@ -476,8 +476,7 @@ final class JellyfinAdvancedNetwork: AdvancedNetworkProtocol {
             // to avoid HLS subtitle sync issues and unnecessary transcoding.
             let needsBurnIn: Bool
             if let codec = subtitleCodec?.lowercased() {
-                let imageBasedCodecs = ["pgssub", "pgs", "dvdsub", "vobsub", "sub", "dvbsub", "dvb_subtitle", "xsub"]
-                needsBurnIn = imageBasedCodecs.contains(codec)
+                needsBurnIn = SubtitleCue.imageBasedCodecs.contains(codec)
             } else {
                 needsBurnIn = true // Unknown codec — use burn-in as fallback
             }

--- a/Stingray/Models/StreamingServiceModel.swift
+++ b/Stingray/Models/StreamingServiceModel.swift
@@ -411,6 +411,57 @@ public final class JellyfinModel: StreamingServiceProtocol {
         title: String,
         subtitle: String?
     ) -> AVPlayer? {
+        let player = AVPlayer()
+        guard let playerItem = prepareStreamingSession(
+            player: player,
+            mediaSource: mediaSource,
+            videoID: videoID,
+            audioID: audioID,
+            subtitleID: subtitleID,
+            bitrate: bitrate,
+            title: title,
+            subtitle: subtitle
+        ) else { return nil }
+        player.replaceCurrentItem(with: playerItem)
+        return player
+    }
+
+    func playbackSwitchTrack(
+        existingPlayer: AVPlayer,
+        mediaSource: any MediaSourceProtocol,
+        videoID: String,
+        audioID: String,
+        subtitleID: String?,
+        bitrate: Bitrate,
+        title: String,
+        subtitle: String?
+    ) -> AVPlayerItem? {
+        self.playerProgress?.stop()
+        self.playerProgress = nil
+        return prepareStreamingSession(
+            player: existingPlayer,
+            mediaSource: mediaSource,
+            videoID: videoID,
+            audioID: audioID,
+            subtitleID: subtitleID,
+            bitrate: bitrate,
+            title: title,
+            subtitle: subtitle
+        )
+    }
+
+    /// Build a streaming player item and configure progress tracking.
+    /// Shared by `playbackStart` (new player) and `playbackSwitchTrack` (reuse player).
+    private func prepareStreamingSession(
+        player: AVPlayer,
+        mediaSource: any MediaSourceProtocol,
+        videoID: String,
+        audioID: String,
+        subtitleID: String?,
+        bitrate: Bitrate,
+        title: String,
+        subtitle: String?
+    ) -> AVPlayerItem? {
         let sessionID = UUID().uuidString
         guard let videoStream = mediaSource.videoStreams.first(where: { $0.id == videoID }) else { return nil }
         let bitrateBits = switch bitrate {
@@ -420,7 +471,6 @@ public final class JellyfinModel: StreamingServiceProtocol {
             setBitrate
         }
 
-        // Look up the subtitle codec so we can choose the optimal delivery method
         let subtitleCodec = subtitleID.flatMap { id in
             mediaSource.subtitleStreams.first(where: { $0.id == id })?.codec
         }
@@ -438,8 +488,7 @@ public final class JellyfinModel: StreamingServiceProtocol {
                 subtitle: subtitle
               )
         else { return nil }
-        let player = AVPlayer(playerItem: playerItem)
-        
+
         self.playerProgress = JellyfinPlayerProgress(
             player: player,
             network: networkAPI,
@@ -453,67 +502,6 @@ public final class JellyfinModel: StreamingServiceProtocol {
             accessToken: self.accessToken
         )
         self.playerProgress?.start()
-        
-        return player
-    }
-    
-    func playbackSwitchTrack(
-        existingPlayer: AVPlayer,
-        mediaSource: any MediaSourceProtocol,
-        videoID: String,
-        audioID: String,
-        subtitleID: String?,
-        bitrate: Bitrate,
-        title: String,
-        subtitle: String?
-    ) -> AVPlayerItem? {
-        // End old progress tracking
-        self.playerProgress?.stop()
-        self.playerProgress = nil
-
-        let sessionID = UUID().uuidString
-        guard let videoStream = mediaSource.videoStreams.first(where: { $0.id == videoID }) else { return nil }
-        let bitrateBits = switch bitrate {
-        case .full:
-            videoStream.bitrate
-        case .limited(let setBitrate):
-            setBitrate
-        }
-
-        // Look up the subtitle codec so we can choose the optimal delivery method
-        let subtitleCodec = subtitleID.flatMap { id in
-            mediaSource.subtitleStreams.first(where: { $0.id == id })?.codec
-        }
-
-        guard let playerItem = networkAPI.getStreamingContent(
-                accessToken: accessToken,
-                contentID: mediaSource.id,
-                bitrate: bitrateBits,
-                subtitleID: subtitleID,
-                subtitleCodec: subtitleCodec,
-                audioID: audioID,
-                videoID: videoID,
-                sessionID: sessionID,
-                title: title,
-                subtitle: subtitle
-              )
-        else { return nil }
-
-        // Reuse existing player — preserves HDR/DV pipeline
-        self.playerProgress = JellyfinPlayerProgress(
-            player: existingPlayer,
-            network: networkAPI,
-            mediaSource: mediaSource,
-            videoID: videoID,
-            audioID: audioID,
-            subtitleID: subtitleID,
-            bitrate: bitrate,
-            playbackSessionID: sessionID,
-            userSessionID: self.sessionID,
-            accessToken: self.accessToken
-        )
-        self.playerProgress?.start()
-
         return playerItem
     }
 

--- a/Stingray/Models/StreamingServiceModel.swift
+++ b/Stingray/Models/StreamingServiceModel.swift
@@ -69,6 +69,13 @@ protocol StreamingServiceProtocol: StreamingServiceBasicProtocol {
         subtitle: String?
     ) -> AVPlayerItem?
 
+    /// Fetch subtitle content as VTT text for client-side rendering.
+    /// - Parameters:
+    ///   - mediaSourceID: The media source ID.
+    ///   - subtitleIndex: The subtitle stream index.
+    /// - Returns: VTT content string, or nil on failure.
+    func fetchSubtitleContent(mediaSourceID: String, subtitleIndex: String) async -> String?
+
     /// Inform the server that playback has ended
     func playbackEnd()
     
@@ -412,12 +419,18 @@ public final class JellyfinModel: StreamingServiceProtocol {
         case .limited(let setBitrate):
             setBitrate
         }
-        
+
+        // Look up the subtitle codec so we can choose the optimal delivery method
+        let subtitleCodec = subtitleID.flatMap { id in
+            mediaSource.subtitleStreams.first(where: { $0.id == id })?.codec
+        }
+
         guard let playerItem = networkAPI.getStreamingContent(
                 accessToken: accessToken,
                 contentID: mediaSource.id,
                 bitrate: bitrateBits,
                 subtitleID: subtitleID,
+                subtitleCodec: subtitleCodec,
                 audioID: audioID,
                 videoID: videoID,
                 sessionID: sessionID,
@@ -467,11 +480,17 @@ public final class JellyfinModel: StreamingServiceProtocol {
             setBitrate
         }
 
+        // Look up the subtitle codec so we can choose the optimal delivery method
+        let subtitleCodec = subtitleID.flatMap { id in
+            mediaSource.subtitleStreams.first(where: { $0.id == id })?.codec
+        }
+
         guard let playerItem = networkAPI.getStreamingContent(
                 accessToken: accessToken,
                 contentID: mediaSource.id,
                 bitrate: bitrateBits,
                 subtitleID: subtitleID,
+                subtitleCodec: subtitleCodec,
                 audioID: audioID,
                 videoID: videoID,
                 sessionID: sessionID,
@@ -496,6 +515,23 @@ public final class JellyfinModel: StreamingServiceProtocol {
         self.playerProgress?.start()
 
         return playerItem
+    }
+
+    func fetchSubtitleContent(mediaSourceID: String, subtitleIndex: String) async -> String? {
+        guard var components = URLComponents(url: serviceURL, resolvingAgainstBaseURL: false) else { return nil }
+        components.path += "/Videos/\(mediaSourceID)/\(mediaSourceID)/Subtitles/\(subtitleIndex)/0/Stream.vtt"
+        guard let url = components.url else { return nil }
+
+        var request = URLRequest(url: url)
+        request.addValue(accessToken, forHTTPHeaderField: "X-MediaBrowser-Token")
+
+        do {
+            let (data, _) = try await URLSession.shared.data(for: request)
+            return String(data: data, encoding: .utf8)
+        } catch {
+            print("Failed to fetch subtitle VTT: \(error)")
+            return nil
+        }
     }
 
     func playbackEnd() {

--- a/Stingray/PlayerView.swift
+++ b/Stingray/PlayerView.swift
@@ -14,25 +14,41 @@ struct PlayerView: View {
     @Binding var navigation: NavigationPath
     
     var body: some View {
-        VStack {
-            if let player = self.vm.player {
-                AVPlayerViewControllerRepresentable(
-                    id: self.vm.mediaSourceID,
-                    player: player,
-                    transportBarCustomMenuItems: makeTransportBarItems(),
-                    streamingService: self.vm.streamingService,
-                    media: self.vm.media,
-                    mediaSource: self.vm.mediaSource
-                ) {
-                    self.vm.navigationPath = self.navigation
-                    dismiss()
-                } onRestoreFromPiP: {
-                    if let restoredPath = self.vm.navigationPath {
-                        self.navigation = restoredPath
+        ZStack(alignment: .bottom) {
+            VStack {
+                if let player = self.vm.player {
+                    AVPlayerViewControllerRepresentable(
+                        id: self.vm.mediaSourceID,
+                        player: player,
+                        transportBarCustomMenuItems: makeTransportBarItems(),
+                        streamingService: self.vm.streamingService,
+                        media: self.vm.media,
+                        mediaSource: self.vm.mediaSource
+                    ) {
+                        self.vm.navigationPath = self.navigation
+                        dismiss()
+                    } onRestoreFromPiP: {
+                        if let restoredPath = self.vm.navigationPath {
+                            self.navigation = restoredPath
+                        }
+                    } onStopFromPiP: {
+                        self.vm.stopPlayer()
                     }
-                } onStopFromPiP: {
-                    self.vm.stopPlayer()
                 }
+            }
+
+            // Subtitle overlay for text-based subtitles rendered client-side
+            if let text = self.vm.currentSubtitleText {
+                Text(text)
+                    .font(.title3)
+                    .foregroundColor(.white)
+                    .multilineTextAlignment(.center)
+                    .shadow(color: .black, radius: 1, x: 1, y: 1)
+                    .shadow(color: .black, radius: 1, x: -1, y: -1)
+                    .shadow(color: .black, radius: 4, x: 0, y: 0)
+                    .padding(.horizontal, 80)
+                    .padding(.bottom, 80)
+                    .allowsHitTesting(false)
             }
         }
         .onDisappear { // Only stop the player if PiP is not active

--- a/Stingray/PlayerViewModel.swift
+++ b/Stingray/PlayerViewModel.swift
@@ -293,7 +293,6 @@ final class PlayerViewModel: Hashable {
     // MARK: - External Subtitle (VTT Overlay)
     // Client-side VTT rendering is used because tvOS AVPlayer doesn't properly handle
     // HLS subtitle delivery — X-TIMESTAMP-MAP=MPEGTS:900000 causes ~9s desync.
-    // This limitation was also observed in Reefy's native tvOS player.
 
     /// Check if a subtitle stream is text-based (can be rendered client-side)
     private func isTextBasedSubtitle(_ subtitleID: String?) -> Bool {

--- a/Stingray/PlayerViewModel.swift
+++ b/Stingray/PlayerViewModel.swift
@@ -11,9 +11,16 @@ import SwiftUI
 
 /// Parsed subtitle cue from a VTT file
 struct SubtitleCue {
+    /// Start time of the cue in seconds
     let startTime: TimeInterval
+    /// End time of the cue in seconds
     let endTime: TimeInterval
+    /// Text content to display
     let text: String
+
+    /// Image-based subtitle codecs that require server-side burn-in (SubtitleMethod=Encode).
+    /// Text-based codecs not in this set are rendered client-side via VTT overlay.
+    static let imageBasedCodecs: Set<String> = ["pgssub", "pgs", "dvdsub", "vobsub", "sub", "dvbsub", "dvb_subtitle", "xsub"]
 }
 
 @Observable
@@ -66,6 +73,8 @@ final class PlayerViewModel: Hashable {
     @ObservationIgnored private var subtitleCues: [SubtitleCue] = []
     /// Periodic time observer for updating subtitle display
     @ObservationIgnored private var subtitleTimeObserver: Any?
+    /// In-flight subtitle fetch task, cancelled on track switch to prevent stale updates
+    @ObservationIgnored private var subtitleLoadTask: Task<Void, Never>?
 
     // Hashable Conformance
     static func == (lhs: PlayerViewModel, rhs: PlayerViewModel) -> Bool {
@@ -282,20 +291,23 @@ final class PlayerViewModel: Hashable {
     }
 
     // MARK: - External Subtitle (VTT Overlay)
+    // Client-side VTT rendering is used because tvOS AVPlayer doesn't properly handle
+    // HLS subtitle delivery — X-TIMESTAMP-MAP=MPEGTS:900000 causes ~9s desync.
+    // This limitation was also observed in Reefy's native tvOS player.
 
     /// Check if a subtitle stream is text-based (can be rendered client-side)
     private func isTextBasedSubtitle(_ subtitleID: String?) -> Bool {
         guard let subtitleID = subtitleID else { return false }
         guard let stream = self.mediaSource.subtitleStreams.first(where: { $0.id == subtitleID }) else { return false }
-        let imageBasedCodecs = ["pgssub", "pgs", "dvdsub", "vobsub", "sub", "dvbsub", "dvb_subtitle", "xsub"]
-        return !imageBasedCodecs.contains(stream.codec.lowercased())
+        return !SubtitleCue.imageBasedCodecs.contains(stream.codec.lowercased())
     }
 
     /// Fetch VTT subtitle content from Jellyfin and set up the time observer for overlay display.
     private func loadExternalSubtitles(subtitleIndex: String) {
+        subtitleLoadTask?.cancel()
         let mediaSourceID = self.mediaSource.id
         let service = self.streamingService
-        Task {
+        subtitleLoadTask = Task {
             guard let vttContent = await service.fetchSubtitleContent(
                 mediaSourceID: mediaSourceID,
                 subtitleIndex: subtitleIndex
@@ -304,10 +316,12 @@ final class PlayerViewModel: Hashable {
                 return
             }
 
+            guard !Task.isCancelled else { return }
             let cues = Self.parseVTT(vttContent)
             print("Loaded \(cues.count) subtitle cues")
 
             await MainActor.run {
+                guard !Task.isCancelled else { return }
                 self.subtitleCues = cues
                 self.startSubtitleTimeObserver()
             }
@@ -316,6 +330,8 @@ final class PlayerViewModel: Hashable {
 
     /// Remove subtitle overlay and stop the time observer.
     private func clearSubtitles() {
+        subtitleLoadTask?.cancel()
+        subtitleLoadTask = nil
         if let observer = subtitleTimeObserver, let player = self.player {
             player.removeTimeObserver(observer)
         }
@@ -347,6 +363,7 @@ final class PlayerViewModel: Hashable {
     }
 
     /// Parse a WebVTT string into an array of subtitle cues.
+    /// Static for testability and because it has no dependency on instance state.
     static func parseVTT(_ content: String) -> [SubtitleCue] {
         var cues: [SubtitleCue] = []
         let lines = content.components(separatedBy: .newlines)
@@ -450,6 +467,7 @@ final class PlayerViewModel: Hashable {
     }
 
     deinit {
+        subtitleLoadTask?.cancel()
         if let observer = subtitleTimeObserver, let player = self.player {
             player.removeTimeObserver(observer)
         }

--- a/Stingray/PlayerViewModel.swift
+++ b/Stingray/PlayerViewModel.swift
@@ -6,7 +6,15 @@
 //
 
 import AVKit
+import Combine
 import SwiftUI
+
+/// Parsed subtitle cue from a VTT file
+struct SubtitleCue {
+    let startTime: TimeInterval
+    let endTime: TimeInterval
+    let text: String
+}
 
 @Observable
 final class PlayerViewModel: Hashable {
@@ -38,30 +46,38 @@ final class PlayerViewModel: Hashable {
     }
     /// Quickly get the media source from the media source ID
     public private(set) var mediaSource: any MediaSourceProtocol
-    
+
     /// Time to start the player at
     public var startTime: CMTime
     /// Current player progress (exposed for observation)
     public var playerProgress: PlayerProtocol?
-    
+    /// Current subtitle text to display as overlay (nil = no subtitle visible)
+    public var currentSubtitleText: String?
+
     /// Server to stream from
     @ObservationIgnored public let streamingService: any StreamingServiceProtocol
     /// Seasons of a TV show if available (may be a movie)
     @ObservationIgnored public let seasons: [(any TVSeasonProtocol)]?
     /// Store and restore the current navigation path
     @ObservationIgnored public var navigationPath: NavigationPath?
-    
+    /// Subscription for observing AVPlayerItem status during track switches
+    @ObservationIgnored private var itemStatusCancellable: AnyCancellable?
+    /// Parsed subtitle cues for the current text subtitle
+    @ObservationIgnored private var subtitleCues: [SubtitleCue] = []
+    /// Periodic time observer for updating subtitle display
+    @ObservationIgnored private var subtitleTimeObserver: Any?
+
     // Hashable Conformance
     static func == (lhs: PlayerViewModel, rhs: PlayerViewModel) -> Bool {
         lhs.mediaSourceID == rhs.mediaSourceID &&
         lhs.startTime == rhs.startTime
     }
-    
+
     func hash(into hasher: inout Hasher) {
         hasher.combine(media.id)
         hasher.combine(startTime.seconds)
     }
-    
+
     /// Normal init for setting up a player
     public init(
         media: any MediaProtocol,
@@ -78,10 +94,10 @@ final class PlayerViewModel: Hashable {
         self.mediaSourceID = mediaSource.id
         self.mediaSource = mediaSource
         self.media = media
-        
+
         var subtitleID: String?
         var bitrate: Bitrate = .full
-        
+
         if let defaultUser = UserModel.shared.getDefaultUser() {
             // Setup subtitles
             if defaultUser.usesSubtitles {
@@ -94,7 +110,7 @@ final class PlayerViewModel: Hashable {
                 bitrate = .limited(bitrateBits)
             }
         }
-        
+
         self.savePlaybackDate()
         self.newPlayer(
             startTime: self.startTime,
@@ -103,9 +119,9 @@ final class PlayerViewModel: Hashable {
             subtitleID: subtitleID,
             bitrate: bitrate
         )
-        
+
     }
-    
+
     /// Creates a new player based on current state
     /// - Parameters:
     ///   - startTime: Where the video should start from
@@ -129,6 +145,9 @@ final class PlayerViewModel: Hashable {
                 print("Failed to configure audio session: \(error)")
             }
         }
+
+        // Clear any existing subtitle overlay
+        clearSubtitles()
 
         var title = ""
         var subtitle = ""
@@ -173,10 +192,44 @@ final class PlayerViewModel: Hashable {
                 subtitle: subtitle
             ) else { return }
 
+            // Cancel any previous item status observation
+            self.itemStatusCancellable?.cancel()
+
             existingPlayer.replaceCurrentItem(with: newItem)
             self.playerProgress = streamingService.playerProgress
             existingPlayer.seek(to: startTime, toleranceBefore: .zero, toleranceAfter: .zero)
             existingPlayer.play()
+
+            // Observe the new item's status to handle load failures gracefully.
+            // If the new stream fails (e.g. transcoding timeout for image-based subtitles),
+            // fall back to playback without subtitles.
+            self.itemStatusCancellable = newItem.publisher(for: \.status)
+                .sink { [weak self] status in
+                    guard let self = self else { return }
+                    switch status {
+                    case .failed:
+                        let errorDescription = newItem.error?.localizedDescription ?? "Unknown error"
+                        print("AVPlayerItem failed to load: \(errorDescription)")
+
+                        // If we were switching subtitles on, retry without subtitles
+                        if resolvedSubtitleID != nil {
+                            print("Retrying playback without subtitles...")
+                            self.itemStatusCancellable?.cancel()
+                            self.newPlayer(
+                                startTime: startTime,
+                                videoID: resolvedVideoID,
+                                audioID: resolvedAudioID,
+                                subtitleID: nil,
+                                bitrate: resolvedBitrate
+                            )
+                        }
+                    case .readyToPlay:
+                        self.itemStatusCancellable?.cancel()
+                        self.itemStatusCancellable = nil
+                    default:
+                        break
+                    }
+                }
         } else {
             // Initial playback: create a new player from scratch
             guard let player = streamingService.playbackStart(
@@ -196,6 +249,11 @@ final class PlayerViewModel: Hashable {
             self.player?.play()
         }
 
+        // Load text-based subtitles as VTT overlay
+        if let subID = resolvedSubtitleID, isTextBasedSubtitle(subID) {
+            loadExternalSubtitles(subtitleIndex: subID)
+        }
+
         // Update user settings
         guard var currentUser = UserModel.shared.getDefaultUser() else { return }
         currentUser.usesSubtitles = self.playerProgress?.subtitleID != nil
@@ -207,7 +265,7 @@ final class PlayerViewModel: Hashable {
         }
         UserModel.shared.updateUser(currentUser)
     }
-    
+
     /// Creates a new player based on current state and new episode
     /// - Parameter episode: Episode to transition into
     public func newPlayer(episode: any TVEpisodeProtocol) {
@@ -222,14 +280,152 @@ final class PlayerViewModel: Hashable {
         }
         self.newPlayer(startTime: .zero, videoID: newVideoStream.id, audioID: newAudioStream.id, subtitleID: newSubtitleStream?.id)
     }
-    
+
+    // MARK: - External Subtitle (VTT Overlay)
+
+    /// Check if a subtitle stream is text-based (can be rendered client-side)
+    private func isTextBasedSubtitle(_ subtitleID: String?) -> Bool {
+        guard let subtitleID = subtitleID else { return false }
+        guard let stream = self.mediaSource.subtitleStreams.first(where: { $0.id == subtitleID }) else { return false }
+        let imageBasedCodecs = ["pgssub", "pgs", "dvdsub", "vobsub", "sub", "dvbsub", "dvb_subtitle", "xsub"]
+        return !imageBasedCodecs.contains(stream.codec.lowercased())
+    }
+
+    /// Fetch VTT subtitle content from Jellyfin and set up the time observer for overlay display.
+    private func loadExternalSubtitles(subtitleIndex: String) {
+        let mediaSourceID = self.mediaSource.id
+        let service = self.streamingService
+        Task {
+            guard let vttContent = await service.fetchSubtitleContent(
+                mediaSourceID: mediaSourceID,
+                subtitleIndex: subtitleIndex
+            ) else {
+                print("Failed to fetch VTT subtitle content")
+                return
+            }
+
+            let cues = Self.parseVTT(vttContent)
+            print("Loaded \(cues.count) subtitle cues")
+
+            await MainActor.run {
+                self.subtitleCues = cues
+                self.startSubtitleTimeObserver()
+            }
+        }
+    }
+
+    /// Remove subtitle overlay and stop the time observer.
+    private func clearSubtitles() {
+        if let observer = subtitleTimeObserver, let player = self.player {
+            player.removeTimeObserver(observer)
+        }
+        subtitleTimeObserver = nil
+        subtitleCues = []
+        currentSubtitleText = nil
+    }
+
+    /// Start a periodic time observer that updates the displayed subtitle text.
+    private func startSubtitleTimeObserver() {
+        guard let player = self.player else { return }
+        // Remove any existing observer
+        if let observer = subtitleTimeObserver {
+            player.removeTimeObserver(observer)
+        }
+
+        // Update subtitles 4 times per second
+        let interval = CMTime(seconds: 0.25, preferredTimescale: CMTimeScale(NSEC_PER_SEC))
+        subtitleTimeObserver = player.addPeriodicTimeObserver(forInterval: interval, queue: .main) { [weak self] time in
+            guard let self = self else { return }
+            let seconds = time.seconds
+            // Binary search would be optimal, but linear search is fine for typical subtitle counts
+            let activeCue = self.subtitleCues.first { seconds >= $0.startTime && seconds < $0.endTime }
+            let newText = activeCue?.text
+            if self.currentSubtitleText != newText {
+                self.currentSubtitleText = newText
+            }
+        }
+    }
+
+    /// Parse a WebVTT string into an array of subtitle cues.
+    static func parseVTT(_ content: String) -> [SubtitleCue] {
+        var cues: [SubtitleCue] = []
+        let lines = content.components(separatedBy: .newlines)
+        var i = 0
+
+        while i < lines.count {
+            let line = lines[i]
+
+            // Look for timestamp lines: "00:01:49.509 --> 00:01:50.575"
+            if line.contains("-->") {
+                let parts = line.components(separatedBy: "-->")
+                guard parts.count == 2 else {
+                    i += 1
+                    continue
+                }
+
+                // Remove positioning metadata after timestamp (e.g. "region:subtitle line:90%")
+                let startStr = parts[0].trimmingCharacters(in: .whitespaces)
+                let endPart = parts[1].trimmingCharacters(in: .whitespaces)
+                let endStr = endPart.components(separatedBy: " ").first ?? endPart
+
+                guard let startTime = parseVTTTimestamp(startStr),
+                      let endTime = parseVTTTimestamp(endStr) else {
+                    i += 1
+                    continue
+                }
+
+                // Collect text lines until empty line or end
+                var textLines: [String] = []
+                i += 1
+                while i < lines.count && !lines[i].trimmingCharacters(in: .whitespaces).isEmpty {
+                    // Strip basic HTML tags
+                    let cleanLine = lines[i]
+                        .replacingOccurrences(of: "<[^>]+>", with: "", options: .regularExpression)
+                    textLines.append(cleanLine)
+                    i += 1
+                }
+
+                let text = textLines.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
+                if !text.isEmpty {
+                    cues.append(SubtitleCue(startTime: startTime, endTime: endTime, text: text))
+                }
+            } else {
+                i += 1
+            }
+        }
+
+        return cues
+    }
+
+    /// Parse a VTT timestamp string (HH:MM:SS.mmm or MM:SS.mmm) into seconds.
+    private static func parseVTTTimestamp(_ str: String) -> TimeInterval? {
+        let parts = str.components(separatedBy: ":")
+        guard parts.count >= 2 else { return nil }
+
+        if parts.count == 3 {
+            // HH:MM:SS.mmm
+            guard let hours = Double(parts[0]),
+                  let minutes = Double(parts[1]),
+                  let seconds = Double(parts[2]) else { return nil }
+            return hours * 3600 + minutes * 60 + seconds
+        } else {
+            // MM:SS.mmm
+            guard let minutes = Double(parts[0]),
+                  let seconds = Double(parts[1]) else { return nil }
+            return minutes * 60 + seconds
+        }
+    }
+
     func stopPlayer() {
+        clearSubtitles()
+        itemStatusCancellable?.cancel()
+        itemStatusCancellable = nil
         player?.pause()
         player = nil
         self.playerProgress = nil
         streamingService.playbackEnd()
     }
-    
+
     func savePlaybackDate() {
         switch self.media.mediaType {
         case .tv(let seasons):
@@ -243,7 +439,7 @@ final class PlayerViewModel: Hashable {
                                 self.mediaSource.startPoint < self.mediaSource.duration * 0.1 {
                                 self.mediaSource.startPoint = 0
                             }
-                            
+
                             print(self.mediaSource.startPoint, self.mediaSource.duration * 0.1, self.mediaSource.duration * 0.9, )
                         }
                     }
@@ -252,8 +448,12 @@ final class PlayerViewModel: Hashable {
         default: break
         }
     }
-    
+
     deinit {
+        if let observer = subtitleTimeObserver, let player = self.player {
+            player.removeTimeObserver(observer)
+        }
+        itemStatusCancellable?.cancel()
         player?.pause()
         streamingService.playbackEnd()
     }


### PR DESCRIPTION
## Summary

- **Fix blue screen on HDR content** when switching audio/subtitle tracks by reusing existing AVPlayer (replaceCurrentItem) instead of recreating it, which preserves the HDR/Dolby Vision pipeline
- **Fix subtitle display** by implementing client-side VTT rendering instead of HLS subtitle delivery, which has a known ~9 second desync on tvOS due to X-TIMESTAMP-MAP PTS mismatch
- Text-based subtitles (SRT/ASS/VTT) are fetched directly from Jellyfin REST API and rendered as SwiftUI overlay synced via AVPlayer.addPeriodicTimeObserver
- Image-based subtitles (PGS/VOBSUB) continue to use server-side burn-in (SubtitleMethod=Encode)

Closes #61
Closes #38

## Changes

### PlayerViewModel.swift
- Split newPlayer() into initial playback (new AVPlayer) and track switch (reuse via replaceCurrentItem)
- Added VTT parser, subtitle cue model, and periodic time observer for client-side subtitle rendering
- Fallback: if stream fails after track switch, retries without subtitles

### StreamingServiceModel.swift
- Added playbackSwitchTrack() for reusing AVPlayer during track switches
- Added fetchSubtitleContent() to download VTT directly from Jellyfin API

### APINetwork.swift
- Added subtitleCodec parameter for smart subtitle method selection
- Text-based subtitles: no subtitle params in HLS URL (rendered client-side)
- Image-based subtitles: SubtitleMethod=Encode (server burn-in)

### PlayerView.swift
- Added SwiftUI subtitle text overlay with shadow outline for readability

## Test plan

- [ ] Play HDR/DV content, switch audio tracks — no blue screen
- [ ] Enable text subtitles (SRT) — displayed correctly, in sync
- [ ] Switch between subtitle tracks — updates without infinite loading
- [ ] Disable subtitles (None) — overlay disappears
- [ ] Enable image-based subtitles (PGS) — server burn-in works