### PR TITLE
Improved user profile selection

### DIFF
--- a/Stingray/APIs/APIUserStorage.swift
+++ b/Stingray/APIs/APIUserStorage.swift
@@ -50,7 +50,10 @@ public final class UserStorage: UserStorageProtocol {
         let method: SettingsModel.ProfileSwitching = (try? self.basicStorage.getSecureData(.userSwitchingMethod)) ?? .askOnLaunch
         switch method {
         case .askOnLaunch: return nil
-        case .manual: return try? self.basicStorage.getSecureData(.defaultStreamingUserID) ?? nil // Fallback to ask
+        case .manual:
+            let userID: String? = try? self.basicStorage.getSecureData(.defaultStreamingUserID) ?? nil // Fallback to ask
+            self.basicStorage.setString(.defaultStreamingUserID, value: userID ?? "")
+            return userID
         case .syncWithTVOS: return self.basicStorage.getString(.defaultStreamingUserID)
         }
     }

--- a/Stingray/APIs/APIUserStorage.swift
+++ b/Stingray/APIs/APIUserStorage.swift
@@ -14,7 +14,7 @@ public protocol UserStorageProtocol {
     /// Set all user IDs to an array of IDs
     /// - Parameter userIDs: User IDs to set
     func setUserIDs(_ userIDs: [String])
-    /// Get the most recently used streaming user ID
+    /// Gets the most recent Jellyfin user's ID. `nil` implies no most recently user, but there may be available users.
     /// - Returns: The user ID
     func getActiveUserID() -> String?
     /// Set the current user to use on startup
@@ -47,11 +47,15 @@ public final class UserStorage: UserStorageProtocol {
     }
     
     public func getActiveUserID() -> String? {
-        self.basicStorage.getString(.defaultStreamingUserID)
+        let method: SettingsModel.ProfileSwitching = (try? self.basicStorage.getSecureData(.userSwitchingMethod)) ?? .askOnLaunch
+        switch method {
+        case .askOnLaunch: return nil
+        case .manual: return try? self.basicStorage.getSecureData(.defaultStreamingUserID) ?? nil // Fallback to ask
+        case .syncWithTVOS: return self.basicStorage.getString(.defaultStreamingUserID)
+        }
     }
     
     public func setActiveUserID(id: String) {
-        // TODO: Stores in both locations, emulating behavior found through v1.1.0
         self.basicStorage.setString(.defaultStreamingUserID, value: id)
         try? self.basicStorage.setSecureData(.defaultStreamingUserID, data: id) // TODO: Silently fails
     }

--- a/Stingray/Models/UserModel.swift
+++ b/Stingray/Models/UserModel.swift
@@ -34,7 +34,7 @@ final class UserModel {
         storage.setUserIDs(userIDs)
     }
     
-    /// Gets the most recent Jellyfin user's ID
+    /// Gets the most recent Jellyfin user's ID. `nil` implies no most recently user, but there may be available users.
     /// - Returns: The most recent user
     func getActiveUser() -> User? {
         guard let userID = self.storage.getActiveUserID() else { return nil }


### PR DESCRIPTION
Support switching user accounts based on three criteria:
- **Ask on Launch**: Stingray will ask you which profile you'd like to use on launch. This is most similar to most streaming platforms.
- **Manual**: Stingray assumes that the last used Jellyfin is the one you want. This is most similar to the existing behavior through v1.1.0.
- **Sync with tvOS**: This maps Jellyfin profiles to tvOS profiles automatically.