### PR TITLE
feat(auth): cleaner code

### DIFF
--- a/Stingray/APIs/APIBasicNetwork.swift
+++ b/Stingray/APIs/APIBasicNetwork.swift
@@ -35,7 +35,7 @@ public protocol BasicNetworkProtocol {
     /// Builds an Authorization header value for the streaming service.
     /// - Parameter accessToken: The access token to include.
     /// - Returns: The formatted Authorization header value.
-    func buildAuthHeader(accessToken: String) -> String
+    func buildAuthHeader(accessToken: String?) -> String
 }
 
 /// Basic descriptor for REST API verbs
@@ -51,7 +51,7 @@ public enum NetworkRequestType: String {
 }
 
 /// A Jellyfin specific basic network struct for making network requests
-public final class JellyfinBasicNetwork: BasicNetworkProtocol, @unchecked Sendable {
+public final class JellyfinBasicNetwork: BasicNetworkProtocol {
     var address: URL
     private let deviceId: String
     private let deviceName: String
@@ -64,8 +64,14 @@ public final class JellyfinBasicNetwork: BasicNetworkProtocol, @unchecked Sendab
         self.deviceName = UIDevice.current.name
     }
     
-    public func buildAuthHeader(accessToken: String) -> String {
-        "MediaBrowser Client=\"Stingray\", Device=\"\(deviceName)\", DeviceId=\"\(deviceId)\", Version=\"\(appVersion)\", Token=\"\(accessToken)\""
+    public func buildAuthHeader(accessToken: String?) -> String {
+        var value = "MediaBrowser Client=\"Stingray\", Device=\"\(deviceName)\", DeviceId=\"\(deviceId)\", Version=\"\(appVersion)\""
+
+        if let token = accessToken {
+            value += ", Token=\"\(token)\""
+        }
+
+        return value
     }
     
     public func request<T: Decodable>(
@@ -87,9 +93,7 @@ public final class JellyfinBasicNetwork: BasicNetworkProtocol, @unchecked Sendab
         request.httpMethod = verb.rawValue
         
         // Jellyfin headers
-        if let accessToken = headers?["X-MediaBrowser-Token"], !accessToken.isEmpty {
-            request.setValue(buildAuthHeader(accessToken: accessToken), forHTTPHeaderField: "Authorization")
-        }
+        request.setValue(buildAuthHeader(accessToken: headers?["X-MediaBrowser-Token"]), forHTTPHeaderField: "Authorization")
         // Only add custom headers if they are provided
         if let headers = headers {
             for header in headers {

--- a/Stingray/APIs/APIBasicNetwork.swift
+++ b/Stingray/APIs/APIBasicNetwork.swift
@@ -31,6 +31,11 @@ public protocol BasicNetworkProtocol {
     ///   - urlParams: URL params to add to URL
     /// - Returns: Formatted URL
     func buildURL(path: String, urlParams: [URLQueryItem]?) -> URL?
+    
+    /// Builds an Authorization header value for the streaming service.
+    /// - Parameter accessToken: The access token to include.
+    /// - Returns: The formatted Authorization header value.
+    func buildAuthHeader(accessToken: String) -> String
 }
 
 /// Basic descriptor for REST API verbs
@@ -46,10 +51,22 @@ public enum NetworkRequestType: String {
 }
 
 /// A Jellyfin specific basic network struct for making network requests
-public final class JellyfinBasicNetwork: BasicNetworkProtocol {
+public final class JellyfinBasicNetwork: BasicNetworkProtocol, @unchecked Sendable {
     var address: URL
+    private let deviceId: String
+    private let deviceName: String
+    private let appVersion: String
     
-    init(address: URL) { self.address = address }
+    init(address: URL) {
+        self.address = address
+        self.appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0.0"
+        self.deviceId = UIDevice.current.identifierForVendor?.uuidString ?? UUID().uuidString
+        self.deviceName = UIDevice.current.name
+    }
+    
+    public func buildAuthHeader(accessToken: String) -> String {
+        "MediaBrowser Client=\"Stingray\", Device=\"\(deviceName)\", DeviceId=\"\(deviceId)\", Version=\"\(appVersion)\", Token=\"\(accessToken)\""
+    }
     
     public func request<T: Decodable>(
         verb: NetworkRequestType,
@@ -70,18 +87,9 @@ public final class JellyfinBasicNetwork: BasicNetworkProtocol {
         request.httpMethod = verb.rawValue
         
         // Jellyfin headers
-        let (deviceId, deviceName) = await MainActor.run {
-            let id = UIDevice.current.identifierForVendor?.uuidString ?? UUID().uuidString
-            let name = UIDevice.current.name
-            return (id, name)
+        if let accessToken = headers?["X-MediaBrowser-Token"], !accessToken.isEmpty {
+            request.setValue(buildAuthHeader(accessToken: accessToken), forHTTPHeaderField: "Authorization")
         }
-        let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0.0"
-        var authHeader = "MediaBrowser Client=\"Stingray\", Device=\"\(deviceName)\", DeviceId=\"\(deviceId)\", Version=\"\(appVersion)\""
-
-        if headers?["X-MediaBrowser-Token"] != nil {
-            authHeader += ", Token=\(headers?["X-MediaBrowser-Token"] ?? "")"
-        }
-        request.setValue(authHeader, forHTTPHeaderField: "Authorization")
         // Only add custom headers if they are provided
         if let headers = headers {
             for header in headers {

--- a/Stingray/APIs/APIBasicNetwork.swift
+++ b/Stingray/APIs/APIBasicNetwork.swift
@@ -52,9 +52,13 @@ public enum NetworkRequestType: String {
 
 /// A Jellyfin specific basic network struct for making network requests
 public final class JellyfinBasicNetwork: BasicNetworkProtocol {
+    /// Address of the Jellyfin server
     var address: URL
+    /// Unique identifier based on the device
     private let deviceId: String
+    /// Human readable device name
     private let deviceName: String
+    /// Current stingray version
     private let appVersion: String
     
     init(address: URL) {
@@ -65,13 +69,11 @@ public final class JellyfinBasicNetwork: BasicNetworkProtocol {
     }
     
     public func buildAuthHeader(accessToken: String?) -> String {
-        var value = "MediaBrowser Client=\"Stingray\", Device=\"\(deviceName)\", DeviceId=\"\(deviceId)\", Version=\"\(appVersion)\""
-
+        var headerValue = "MediaBrowser Client=\"Stingray\", Device=\"\(deviceName)\", DeviceId=\"\(deviceId)\", Version=\"\(appVersion)\""
         if let token = accessToken {
-            value += ", Token=\"\(token)\""
+            headerValue += ", Token=\"\(token)\""
         }
-
-        return value
+        return headerValue
     }
     
     public func request<T: Decodable>(

--- a/Stingray/APIs/APINetwork.swift
+++ b/Stingray/APIs/APINetwork.swift
@@ -475,7 +475,8 @@ final class JellyfinAdvancedNetwork: AdvancedNetworkProtocol {
         guard let item = self.buildAVPlayerItem(
             path: "/Videos/\(contentID)/main.m3u8",
             urlParams: params,
-            headers: ["X-MediaBrowser-Token": accessToken]
+            // TODO: remove X-MediaBrowser-Token when the backward compatibility is no longer required
+            headers: ["X-MediaBrowser-Token": accessToken, "Authorization": network.buildAuthHeader(accessToken: accessToken)]
         ) else { return nil }
         
         // Set the title metadata


### PR DESCRIPTION
It provides a cleaner way to generate the auth token.
`buildAuthHeader` generates the Authorization value token and it regenerates the Authorization header if the `X-MediaBrowser-Token` is present.
