### PR TITLE
Move authentication tokens from UserDefaults to Keychain

### DIFF
--- a/Stingray/APIs/APIUserStorage.swift
+++ b/Stingray/APIs/APIUserStorage.swift
@@ -6,6 +6,68 @@
 //
 
 import Foundation
+import Security
+
+/// Secure Keychain storage for authentication tokens
+enum KeychainTokenStorage {
+    private static let service = "com.benlab.stingray.tokens"
+
+    /// Store access token and session ID securely in the Keychain
+    static func storeTokens(accessToken: String, sessionID: String, forUserID userID: String) {
+        let tokenData: [String: String] = [
+            "accessToken": accessToken,
+            "sessionID": sessionID
+        ]
+        guard let data = try? JSONEncoder().encode(tokenData) else { return }
+
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: userID
+        ]
+
+        // Delete any existing item first
+        SecItemDelete(query as CFDictionary)
+
+        var addQuery = query
+        addQuery[kSecValueData as String] = data
+        addQuery[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+        SecItemAdd(addQuery as CFDictionary, nil)
+    }
+
+    /// Retrieve tokens from the Keychain
+    static func getTokens(forUserID userID: String) -> (accessToken: String, sessionID: String)? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: userID,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+
+        guard status == errSecSuccess,
+              let data = result as? Data,
+              let tokenData = try? JSONDecoder().decode([String: String].self, from: data),
+              let accessToken = tokenData["accessToken"],
+              let sessionID = tokenData["sessionID"]
+        else { return nil }
+
+        return (accessToken, sessionID)
+    }
+
+    /// Delete tokens from the Keychain
+    static func deleteTokens(forUserID userID: String) {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: userID
+        ]
+        SecItemDelete(query as CFDictionary)
+    }
+}
 
 /// Local storage for modifying user-related data
 public protocol UserStorageProtocol {
@@ -55,19 +117,77 @@ public final class UserStorage: UserStorageProtocol {
     }
     
     public func setUser(user: User) {
-        if let encoded = try? JSONEncoder().encode(user),
-           let jsonString = String(data: encoded, encoding: .utf8) {
-            self.basicStorage.setString(.user, id: user.id, value: jsonString)
+        // Save tokens securely to Keychain
+        switch user.serviceType {
+        case .Jellyfin(let jellyfin):
+            KeychainTokenStorage.storeTokens(
+                accessToken: jellyfin.accessToken,
+                sessionID: jellyfin.sessionID,
+                forUserID: user.id
+            )
+        }
+
+        // Save user to UserDefaults with tokens stripped
+        guard let encoded = try? JSONEncoder().encode(user),
+              var jsonDict = try? JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        else { return }
+
+        // Strip sensitive tokens from UserDefaults storage
+        if var serviceType = jsonDict["serviceType"] as? [String: Any],
+           var jellyfinData = serviceType["jellyfinData"] as? [String: Any] {
+            jellyfinData["accessToken"] = ""
+            jellyfinData["sessionID"] = ""
+            serviceType["jellyfinData"] = jellyfinData
+            jsonDict["serviceType"] = serviceType
+        }
+
+        if let sanitizedData = try? JSONSerialization.data(withJSONObject: jsonDict),
+           let sanitizedString = String(data: sanitizedData, encoding: .utf8) {
+            self.basicStorage.setString(.user, id: user.id, value: sanitizedString)
         }
     }
     
     public func getUser(userID: String) -> User? {
         guard let jsonString = self.basicStorage.getString(.user, id: userID),
               let data = jsonString.data(using: .utf8) else { return nil }
-        return try? JSONDecoder().decode(User.self, from: data)
+
+        // Try to inject tokens from Keychain
+        if let tokens = KeychainTokenStorage.getTokens(forUserID: userID),
+           var jsonDict = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+           var serviceType = jsonDict["serviceType"] as? [String: Any],
+           var jellyfinData = serviceType["jellyfinData"] as? [String: Any] {
+            jellyfinData["accessToken"] = tokens.accessToken
+            jellyfinData["sessionID"] = tokens.sessionID
+            serviceType["jellyfinData"] = jellyfinData
+            jsonDict["serviceType"] = serviceType
+
+            if let enrichedData = try? JSONSerialization.data(withJSONObject: jsonDict) {
+                return try? JSONDecoder().decode(User.self, from: enrichedData)
+            }
+        }
+
+        // Fallback: decode as-is (migration from old storage where tokens are still in UserDefaults)
+        guard let user = try? JSONDecoder().decode(User.self, from: data) else { return nil }
+
+        // Migrate tokens to Keychain and strip from UserDefaults
+        switch user.serviceType {
+        case .Jellyfin(let jellyfin):
+            if !jellyfin.accessToken.isEmpty {
+                KeychainTokenStorage.storeTokens(
+                    accessToken: jellyfin.accessToken,
+                    sessionID: jellyfin.sessionID,
+                    forUserID: userID
+                )
+                // Re-save to strip tokens from UserDefaults
+                self.setUser(user: user)
+            }
+        }
+
+        return user
     }
     
     public func deleteUser(userID: String) {
+        KeychainTokenStorage.deleteTokens(forUserID: userID)
         self.basicStorage.deleteString(.user, id: userID)
     }
 }


### PR DESCRIPTION
## Summary

  - **Security fix**: Access tokens and session IDs were stored as plaintext JSON in UserDefaults, making them extractable via device backups, jailbreak, or forensic tools. They are now stored in the system Keychain using
  `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`.
  - **Automatic migration**: Existing users are seamlessly migrated on first app launch — tokens are moved to Keychain and stripped from UserDefaults without requiring re-authentication.
  - **No breaking changes**: The `User` struct and all consuming code remain unchanged; only the storage layer was modified.

  ## What changed

  - Added `KeychainTokenStorage` enum with `storeTokens`, `getTokens`, and `deleteTokens` methods
  - `UserStorage.setUser()` now saves tokens to Keychain and writes empty placeholders to UserDefaults
  - `UserStorage.getUser()` injects tokens from Keychain back into the User object, with fallback migration from old UserDefaults format
  - `UserStorage.deleteUser()` now cleans up Keychain entries alongside UserDefaults

  ## Test plan

  - [ ] Fresh install: sign in and verify API calls work (tokens stored in Keychain)
  - [ ] Existing install: update app and verify auto-login still works (migration path)
  - [ ] Switch users: verify each user's tokens are stored/retrieved independently
  - [ ] Logout: verify tokens are removed from Keychain
  - [ ] Top Shelf extension: verify it can still fetch content after update