### PR TITLE
Group consecutive specials under a single Specials header

### DIFF
--- a/Stingray/Models/MediaModel.swift
+++ b/Stingray/Models/MediaModel.swift
@@ -608,11 +608,16 @@ public final class TVSeason: TVSeasonProtocol {
                 
                 let seasonTitle = try episodeContainer.decodeIfPresent(String.self, forKey: .seasonTitle) ?? "Unknown Season"
                 if seasonTitle == "Specials" { // Episode is a special
-                    let newSeason = TVSeason(
-                        title: "Special",
-                        episodes: [episode]
-                    )
-                    tempSeasons.append(newSeason)
+                    if tempSeasons.last?.title == "Special" { // Coalesce consecutive specials into one Specials season
+                        tempSeasons.last?.episodes.append(episode)
+                    }
+                    else {
+                        let newSeason = TVSeason(
+                            title: "Special",
+                            episodes: [episode]
+                        )
+                        tempSeasons.append(newSeason)
+                    }
                 }
                 else if seasonID == lastSeasonID && tempSeasons.last?.title == "Special" { // Season was split by specials
                     lastSeasonID = seasonID


### PR DESCRIPTION
## Summary
`TVSeason.decodeSeasons(from:)` created a brand-new `TVSeason(title: "Special", ...)` for every special episode, so a show with multiple specials rendered a run of repeated `Special` season headers (`Season 1` -> `Special` -> `Special` -> `Special` -> `Season 2`). This changes the `"Specials"` branch to append the episode to the existing trailing special season when one is already present, so consecutive specials coalesce into a single special season between the regular seasons.

## Why this matters
This restores the grouping the maintainer confirmed as the desired behavior in https://github.com/benjaminRoberts01375/Stingray/issues/70 (`Season 1` -> `Specials` -> `Season 2`), removing the long runs of duplicate `Special` headers in the season selector. `lastSeasonID` is intentionally left untouched in this branch, so a regular season resuming after the specials still triggers the existing `" Cont."` split logic.

## Testing
The tvOS 26.4 platform runtime is not installed on this machine (only the SDK headers), so a full headless app build/simulator run was not possible. I extracted the coalescing logic into a standalone Swift harness (`swiftc`) and verified all four scenarios from the issue: (1) three consecutive specials between Season 1 and Season 2 collapse into one special season holding all three episodes; (2) a regular season resuming after specials still produces the `" Cont."` split; (3) a lone special still yields one special season with one episode; (4) a show with zero specials is byte-for-byte identical to before. The change is scoped to the single `if seasonTitle == "Specials"` branch.

Fixes #70
